### PR TITLE
fix: add spaces when the space between 2 words' bbox is large

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `exclude_background_colored_edges` parameter to `TfSettings` (default: `True`) to replace `exclude_white_edges` (#20). Uses a spatial visibility algorithm: for each edge, the fill colors of the rectangles directly adjacent on both sides (within `snap_tolerance`) are inspected. An edge is excluded only when it is indistinguishable from its surroundings on all effective sides (missing sides default to the standard white PDF page background). This correctly handles pages with mixed-background tables and non-white backgrounds.
 
+### Fixed
+
+- **Cell text spacing:** A space is now inserted between two words in a table cell only when the gap between their bounding boxes (in reading direction) exceeds the word-extraction tolerance (`x_tolerance` for horizontal text, `y_tolerance` for vertical). This preserves visible gaps in languages like English (e.g. "Table 1" and "Abcd") while avoiding unwanted spaces in languages that do not use spaces between words (e.g. Chinese).
+
 ### Changed
 
 - **Breaking:** `exclude_white_edges` has been removed and replaced by `exclude_background_colored_edges`. The new parameter is `True` by default and subsumes the old behavior on white-background pages. Rename any existing `exclude_white_edges=False` to `exclude_background_colored_edges=False`.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -428,6 +428,9 @@ Represents a single cell in a table.
 | `bbox` | `tuple[float, float, float, float]` | Bounding box (x1, y1, x2, y2) |
 | `text` | `str` | Text content of the cell |
 
+!!! note "How cell text is built"
+    Cell text is produced by grouping characters into words (using [WordsExtractSettings](../reference/settings.md#wordsextractsettings)) and then joining those words. A **space is inserted between two consecutive words only when the gap between their bounding boxes** (in reading direction) **exceeds** the word-extraction tolerance (`x_tolerance` for horizontal text, `y_tolerance` for vertical). As a result, visible gaps in the PDF (e.g. between "Table 1" and "Abcd") are reflected as spaces, while languages that do not use spaces between words (e.g. Chinese) do not get extra spaces.
+
 ---
 
 ### CellGroup

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -173,8 +173,8 @@ we_settings = WordsExtractSettings(
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `x_tolerance` | `float` | `3.0` | Horizontal tolerance for grouping characters into words |
-| `y_tolerance` | `float` | `3.0` | Vertical tolerance for grouping characters into lines |
+| `x_tolerance` | `float` | `3.0` | Horizontal tolerance for grouping characters into words; also used when building table cell text to decide whether to insert a space between two words (space inserted only when the gap between their bboxes exceeds this value) |
+| `y_tolerance` | `float` | `3.0` | Vertical tolerance for grouping characters into lines; also used for vertical text when deciding whether to insert a space between two words in a cell |
 | `keep_blank_chars` | `bool` | `False` | Whether to preserve blank/whitespace characters |
 | `use_text_flow` | `bool` | `False` | Whether to use the PDF's text flow order |
 | `text_read_in_clockwise` | `bool` | `True` | Whether text reads in clockwise direction |

--- a/docs/usage/advanced.md
+++ b/docs/usage/advanced.md
@@ -81,12 +81,14 @@ with Document("example.pdf") as doc:
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `x_tolerance` | 3.0 | Horizontal tolerance for grouping characters into words |
-| `y_tolerance` | 3.0 | Vertical tolerance for grouping characters into lines |
+| `x_tolerance` | 3.0 | Horizontal tolerance for grouping characters into words; also controls when a space is inserted between two words in cell text (only when the gap between their bboxes exceeds this value) |
+| `y_tolerance` | 3.0 | Vertical tolerance for grouping characters into lines; same role for vertical text when building cell text |
 | `keep_blank_chars` | False | Whether to preserve whitespace characters |
 | `use_text_flow` | False | Whether to use PDF's text flow order |
 | `expand_ligatures` | True | Whether to expand ligatures (fi, fl, etc.) |
 | `need_strip` | True | Whether to strip whitespace from cell text |
+
+This ensures that languages like English get spaces where the PDF has visible gaps (e.g. "Table 1" and "Abcd"), while languages that do not use spaces between words (e.g. Chinese) do not get extra spaces.
 
 ## Two-Step Table Extraction
 

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -560,6 +560,39 @@ impl Table {
         Self::get_rows_or_cols(&self.cells, CellGroupKind::Column)
     }
 
+    /// Returns `true` when the gap between two consecutive words (in reading direction) exceeds
+    /// the relevant tolerance, indicating that a space should be inserted when joining them.
+    ///
+    /// The gap direction and tolerance axis are chosen from `next`'s rotation:
+    /// - LTR / RTL (horizontal): compares horizontal bbox edges, uses `x_tol`.
+    /// - Top-to-bottom / bottom-to-top (vertical): compares vertical bbox edges, uses `y_tol`.
+    ///
+    /// **Assumption**: `prev` and `next` share the same reading direction. When a cell contains
+    /// mixed-rotation text the result is undefined and this function uses `next`'s rotation only.
+    #[inline]
+    fn word_gap_requires_space(prev: &Word, next: &Word, x_tol: f32, y_tol: f32) -> bool {
+        let r = next.rotation_degrees;
+        let gap = if rotation_is_ltr(r) {
+            // horizontal LTR: gap = next left − prev right
+            next.bbox.0 - prev.bbox.2
+        } else if r >= OrderedFloat(45.0f32) && r < OrderedFloat(135.0f32) {
+            // vertical top-to-bottom: gap = next top − prev bottom
+            next.bbox.1 - prev.bbox.3
+        } else if r >= OrderedFloat(135.0f32) && r < OrderedFloat(225.0f32) {
+            // horizontal RTL: gap = prev left − next right
+            prev.bbox.0 - next.bbox.2
+        } else {
+            // vertical bottom-to-top: gap = prev top − next bottom
+            prev.bbox.1 - next.bbox.3
+        };
+        let tol = if rotation_is_horizontal(r) {
+            OrderedFloat(x_tol)
+        } else {
+            OrderedFloat(y_tol)
+        };
+        gap > tol
+    }
+
     /// Checks if a character's center is within a bounding box.
     ///
     /// # Arguments
@@ -598,6 +631,8 @@ impl Table {
             ..base_settings.clone()
         };
         let word_extractor = WordExtractor::new(&word_settings);
+        let x_tol = word_settings.x_tolerance.into_inner();
+        let y_tol = word_settings.y_tolerance.into_inner();
 
         for cell in &mut self.cells {
             let cell_chars: Vec<Char> = chars
@@ -608,11 +643,16 @@ impl Table {
 
             if !cell_chars.is_empty() {
                 let words = word_extractor.extract_words(&cell_chars);
-                let mut text = words
-                    .iter()
-                    .map(|w| w.text.replace("\r\n", "\n").replace('\r', "\n"))
-                    .collect::<Vec<_>>()
-                    .join("");
+                let mut text = String::new();
+                for (i, w) in words.iter().enumerate() {
+                    if i > 0 {
+                        let prev = &words[i - 1];
+                        if Self::word_gap_requires_space(prev, w, x_tol, y_tol) {
+                            text.push(' ');
+                        }
+                    }
+                    text.push_str(&w.text.replace("\r\n", "\n").replace('\r', "\n"));
+                }
                 if need_strip {
                     text = text.trim().to_string();
                 }
@@ -2328,6 +2368,63 @@ mod tests {
 
         // Char center is (16.5, 16.5), which is outside the bbox
         assert!(!Table::char_in_bbox(&char, &bbox));
+    }
+
+    fn make_word(x1: f32, y1: f32, x2: f32, y2: f32, rotation: f32) -> Word {
+        Word {
+            text: "w".to_string(),
+            bbox: (of(x1), of(y1), of(x2), of(y2)),
+            rotation_degrees: of(rotation),
+        }
+    }
+
+    #[test]
+    fn test_word_gap_requires_space_ltr_gap_exceeds_tol() {
+        // LTR (r=0°): prev ends at x=5, next starts at x=8 → gap=3 > x_tol=2
+        let prev = make_word(0.0, 0.0, 5.0, 10.0, 0.0);
+        let next = make_word(8.0, 0.0, 15.0, 10.0, 0.0);
+        assert!(Table::word_gap_requires_space(&prev, &next, 2.0, 5.0));
+    }
+
+    #[test]
+    fn test_word_gap_requires_space_ltr_gap_equals_tol_no_space() {
+        // gap == tol is NOT strictly greater, so no space
+        let prev = make_word(0.0, 0.0, 5.0, 10.0, 0.0);
+        let next = make_word(8.0, 0.0, 15.0, 10.0, 0.0);
+        assert!(!Table::word_gap_requires_space(&prev, &next, 3.0, 5.0));
+    }
+
+    #[test]
+    fn test_word_gap_requires_space_ltr_wraparound_uses_x_tol() {
+        // LTR wrap-around (r=320°): should use x_tol, not y_tol
+        // gap=3 > x_tol=2 → true; gap=3 <= y_tol=5 would give false if wrong tol were used
+        let prev = make_word(0.0, 0.0, 5.0, 10.0, 320.0);
+        let next = make_word(8.0, 0.0, 15.0, 10.0, 320.0);
+        assert!(Table::word_gap_requires_space(&prev, &next, 2.0, 5.0));
+    }
+
+    #[test]
+    fn test_word_gap_requires_space_vertical_ttb_gap_exceeds_tol() {
+        // Vertical top-to-bottom (r=90°): prev ends at y=5, next starts at y=8 → gap=3 > y_tol=2
+        let prev = make_word(0.0, 0.0, 10.0, 5.0, 90.0);
+        let next = make_word(0.0, 8.0, 10.0, 15.0, 90.0);
+        assert!(Table::word_gap_requires_space(&prev, &next, 5.0, 2.0));
+    }
+
+    #[test]
+    fn test_word_gap_requires_space_rtl_gap_exceeds_tol() {
+        // RTL (r=180°): gap = prev.bbox.0 − next.bbox.2 = 8 − 5 = 3 > x_tol=2
+        let prev = make_word(8.0, 0.0, 15.0, 10.0, 180.0);
+        let next = make_word(0.0, 0.0, 5.0, 10.0, 180.0);
+        assert!(Table::word_gap_requires_space(&prev, &next, 2.0, 5.0));
+    }
+
+    #[test]
+    fn test_word_gap_requires_space_vertical_btt_gap_exceeds_tol() {
+        // Vertical bottom-to-top (r=270°): gap = prev.bbox.1 − next.bbox.3 = 8 − 5 = 3 > y_tol=2
+        let prev = make_word(0.0, 8.0, 10.0, 15.0, 270.0);
+        let next = make_word(0.0, 0.0, 10.0, 5.0, 270.0);
+        assert!(Table::word_gap_requires_space(&prev, &next, 5.0, 2.0));
     }
 
     #[test]

--- a/src/words.rs
+++ b/src/words.rs
@@ -25,6 +25,23 @@ static LIGATURES: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(
 static PUNCTUATIONS: LazyLock<HashSet<char>> =
     LazyLock::new(|| "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~".chars().collect());
 
+/// Returns `true` when the rotation indicates left-to-right horizontal text
+/// (approximately 0° including the [315°, 360°) wrap-around).
+#[inline]
+pub(crate) fn rotation_is_ltr(r: OrderedFloat<f32>) -> bool {
+    (r >= OrderedFloat(-0.001f32) && r < OrderedFloat(45.0f32))
+        || (r >= OrderedFloat(315.0f32) && r < OrderedFloat(360.001f32))
+}
+
+/// Returns `true` when the rotation indicates horizontal text (LTR **or** RTL).
+///
+/// Covers [−0.001°, 45°), [135°, 225°), and [315°, 360.001°).
+/// Use this to pick `x_tolerance` over `y_tolerance` for inter-word gap checks.
+#[inline]
+pub(crate) fn rotation_is_horizontal(r: OrderedFloat<f32>) -> bool {
+    rotation_is_ltr(r) || (r >= OrderedFloat(135.0f32) && r < OrderedFloat(225.0f32))
+}
+
 /// Represents a word extracted from PDF text.
 ///
 /// A word is a sequence of characters grouped by proximity and alignment.
@@ -35,7 +52,6 @@ pub(crate) struct Word {
     /// The bounding box of the word.
     pub bbox: BboxKey,
     /// The rotation of the word in degrees.
-    #[allow(dead_code)]
     pub rotation_degrees: OrderedFloat<f32>,
 }
 

--- a/tests/python/test_tables.py
+++ b/tests/python/test_tables.py
@@ -843,6 +843,34 @@ class TestNestedXobj:
             f"y2 mismatch: expected {expected_bbox[3]}, got {actual_bbox[3]}"
         )
 
+    def test_nested_xobj_first_cell_text_has_space_between_words(
+        self, nested_xobj_doc: Document
+    ) -> None:
+        """
+        First cell contains "Table 1" and "Abcd" with a visible gap in the PDF.
+        Extracted text must have a space between them (not "Table 1Abcd").
+        """
+        page = nested_xobj_doc.get_page(0)
+        tables = find_tables(page, extract_text=True)
+        assert len(tables) == 1
+        table = tables[0]
+        assert len(table.cells) > 0
+        first_cell_text = table.cells[0].text
+        # "Table 1" and "Abcd" must be separated by at least one space
+        assert "Table 1" in first_cell_text and "Abcd" in first_cell_text, (
+            f"First cell should contain 'Table 1' and 'Abcd', got: {first_cell_text!r}"
+        )
+        assert "Table 1Abcd" not in first_cell_text, (
+            f"First cell text must have space between 'Table 1' and 'Abcd', got: {first_cell_text!r}"
+        )
+        idx_table1 = first_cell_text.find("Table 1")
+        idx_abcd = first_cell_text.find("Abcd")
+        assert idx_table1 < idx_abcd, "Abcd should appear after Table 1"
+        between = first_cell_text[idx_table1 + len("Table 1") : idx_abcd]
+        assert " " in between, (
+            f"Expected at least one space between 'Table 1' and 'Abcd', got: {between!r}"
+        )
+
 
 class TestNarrowPolylineAsEdge:
     """Tests for #13-narrow-polyline-as-edge.pdf table extraction."""

--- a/tests/python/test_tables.py
+++ b/tests/python/test_tables.py
@@ -861,7 +861,8 @@ class TestNestedXobj:
             f"First cell should contain 'Table 1' and 'Abcd', got: {first_cell_text!r}"
         )
         assert "Table 1Abcd" not in first_cell_text, (
-            f"First cell text must have space between 'Table 1' and 'Abcd', got: {first_cell_text!r}"
+            "First cell text must have space between 'Table 1' and 'Abcd', "
+            f"got: {first_cell_text!r}"
         )
         idx_table1 = first_cell_text.find("Table 1")
         idx_abcd = first_cell_text.find("Abcd")


### PR DESCRIPTION
In current codes, e.g., for "tests/data/nested-xobj.pdf", the text in the first cell would be "Table 1Abcd", while it should be "Table 1 Abcd" because there's a large space between "Table 1" and "Abcd".

This PR aims to fix this bug by considering bboxes' coordinate diff.