### PR TITLE
feat: support pickle for all pure-data types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Pickle support:** All pure-data types (`Table`, `TableCell`, `CellGroup`, `TableCellValue`, `Edge`, `Objects`, `Rect`, `Line`, `Char`, `FillMode`, `TfSettings`, `WordsExtractSettings`) now implement `__reduce__` and can be serialized/deserialized via the Python `pickle` protocol. This enables passing extracted tables directly between processes with `multiprocessing` without manual conversion to plain Python types.
+
 ### Changed
 
 - Type stubs (`tablers.pyi`) are now auto-generated using [rylai](https://github.com/monchin/rylai) instead of being manually maintained. Run `pdm stub` to regenerate.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ For more details, please refer to the [tablers-benchmark](https://github.com/mon
 
 ## Note
 
-This solution is primarily designed for text-based PDFs and does not support scanned PDFs.
+- This solution is primarily designed for text-based PDFs and does not support scanned PDFs.
+- **Thread Safety**: `tablers` is **not thread-safe**. The library creates a global PDFium runtime at import time, which is bound to the importing thread. All `Document` operations must be performed on the same thread that imported `tablers`. Using `Document` from a different thread will raise a `PanicException`. For multi-threaded environments, import and use `tablers` within the same worker thread. Use `multiprocessing` for parallel processing instead. See [Thread Safety](docs/usage/advanced.md#thread-safety) for details and code examples.
 
 ## Installation
 

--- a/docs/usage/advanced.md
+++ b/docs/usage/advanced.md
@@ -430,7 +430,7 @@ Once all virtual edges are synthesised, the full intersection-detection and cell
 
 **`tablers` is not thread-safe.** The library creates a global `PDFIUM_RT` runtime at import time, which is bound to the importing thread. All `Document` operations must be performed on the same thread that imported `tablers`. Using `Document` from a different thread will raise a `PanicException`:
 
-```
+```text
 PanicException: assertion `left == right` failed: tablers::PdfiumRuntime is unsendable, but sent to another thread
 ```
 
@@ -471,6 +471,8 @@ threading.Thread(target=worker).start()
 
 For parallel processing, use `multiprocessing` instead of `threading`. Each process gets its own Python interpreter and global runtime, so `tablers` works correctly in each child process:
 
+All pure-data objects (`Table`, `TableCell`, `Edge`, `TfSettings`, etc.) support the Python pickle protocol and can be returned directly from worker processes:
+
 ```python
 from multiprocessing import Pool
 
@@ -483,12 +485,10 @@ def process_page_range(args):
         for page_num in range(start, end):
             page = doc.get_page(page_num)
             tables = find_tables(page, extract_text=True)
-            # Table / TableCellValue objects cannot be pickled across processes,
-            # so convert to plain Python types before returning.
-            results.append([
-                [[cell.text for cell in row] for row in t.to_list()]
-                for t in tables
-            ])
+            # Table objects are picklable — return them directly!
+            # Note: Document and Page objects are NOT picklable and must
+            # stay in the process that created them.
+            results.append(tables)
     return results
 
 if __name__ == "__main__":
@@ -511,6 +511,18 @@ if __name__ == "__main__":
     with Pool(num_workers) as pool:
         results = pool.map(process_page_range, ranges)
 ```
+
+#### Picklable Types
+
+The following types support pickle and can be freely passed between processes:
+
+- `Table`, `TableCell`, `CellGroup`, `TableCellValue`
+- `Edge`, `Objects`, `Rect`, `Line`, `Char`, `FillMode`
+- `TfSettings`, `WordsExtractSettings`
+
+The following types are **not** picklable because they hold native Pdfium resources and should stay in the process that created them:
+
+- `PdfiumRuntime`, `Document`, `Pyo3Page`, `PageIterator`
 
 ## Error Handling
 

--- a/docs/usage/advanced.md
+++ b/docs/usage/advanced.md
@@ -426,6 +426,92 @@ The algorithm runs as a pre-processing step on the raw collected edges, before i
 
 Once all virtual edges are synthesised, the full intersection-detection and cell-detection pipeline is re-run with the enhanced edge set. The feature is **skipped entirely** when either `vertical_strategy` or `horizontal_strategy` is `"text"`, because text-derived edges can extend across table boundaries in ways that would produce false-positive extra columns or rows.
 
+## Thread Safety
+
+**`tablers` is not thread-safe.** The library creates a global `PDFIUM_RT` runtime at import time, which is bound to the importing thread. All `Document` operations must be performed on the same thread that imported `tablers`. Using `Document` from a different thread will raise a `PanicException`:
+
+```
+PanicException: assertion `left == right` failed: tablers::PdfiumRuntime is unsendable, but sent to another thread
+```
+
+### Why Not Thread-Safe?
+
+tablers is built on [pdfium-render](https://github.com/ajrcarey/pdfium-render), which in turn wraps Pdfium. Pdfium itself is [explicitly not thread-safe](https://github.com/ajrcarey/pdfium-render#multi-threading) — the Pdfium authors recommend parallel processing over multi-threading. Although pdfium-render offers a `thread_safe` compile-time feature that locks access to Pdfium behind a mutex, enabling it would introduce performance overhead (mutex acquisition even in single-threaded use) and requires an explicit compile-time feature declaration. For these reasons, tablers does not enable thread safety and recommends `multiprocessing` for parallel workloads.
+
+### Multi-Threaded Environments
+
+In multi-threaded environments (e.g., FastAPI, Celery), make sure to import and use `tablers` within the same worker thread:
+
+```python
+# ❌ Wrong: import on main thread, use on worker thread
+import threading
+from tablers import Document
+
+def worker():
+    with Document("example.pdf") as doc:  # PanicException!
+        pass
+
+threading.Thread(target=worker).start()
+```
+
+```python
+# ✅ Correct: import and use on the same worker thread
+import threading
+
+def worker():
+    from tablers import Document, find_tables  # Import inside the worker thread
+    with Document("example.pdf") as doc:
+        for page in doc.pages():
+            tables = find_tables(page, extract_text=True)
+
+threading.Thread(target=worker).start()
+```
+
+### Multiprocessing
+
+For parallel processing, use `multiprocessing` instead of `threading`. Each process gets its own Python interpreter and global runtime, so `tablers` works correctly in each child process:
+
+```python
+from multiprocessing import Pool
+
+def process_page_range(args):
+    """Each worker opens the document once and processes a contiguous range of pages."""
+    pdf_path, start, end = args
+    from tablers import Document, find_tables
+    results = []
+    with Document(pdf_path) as doc:
+        for page_num in range(start, end):
+            page = doc.get_page(page_num)
+            tables = find_tables(page, extract_text=True)
+            # Table / TableCellValue objects cannot be pickled across processes,
+            # so convert to plain Python types before returning.
+            results.append([
+                [[cell.text for cell in row] for row in t.to_list()]
+                for t in tables
+            ])
+    return results
+
+if __name__ == "__main__":
+    import os
+    from tablers import Document
+
+    pdf_path = "example.pdf"
+    num_workers = os.cpu_count() or 4
+
+    with Document(pdf_path) as doc:
+        page_count = doc.page_count
+
+    # Split pages into contiguous chunks, one per worker
+    chunk_size = max(1, (page_count + num_workers - 1) // num_workers)
+    ranges = [
+        (pdf_path, i, min(i + chunk_size, page_count))
+        for i in range(0, page_count, chunk_size)
+    ]
+
+    with Pool(num_workers) as pool:
+        results = pool.map(process_page_range, ranges)
+```
+
 ## Error Handling
 
 ```python

--- a/python/tablers/__init__.py
+++ b/python/tablers/__init__.py
@@ -36,6 +36,14 @@ Although `pdfium-render <https://github.com/ajrcarey/pdfium-render#multi-threadi
 offers a ``thread_safe`` compile-time feature (mutex-based locking),
 enabling it would introduce performance overhead in single-threaded
 use, so tablers does not enable it.
+
+**Pickle Support**: All pure-data objects (``Table``, ``TableCell``,
+``Edge``, ``TfSettings``, ``WordsExtractSettings``, ``Objects``,
+``Rect``, ``Line``, ``Char``, ``CellGroup``,
+``TableCellValue``) support the Python pickle protocol and can be
+passed between processes via ``multiprocessing``. The Pdfium-bound
+types (``PdfiumRuntime``, ``Document``, ``Pyo3Page``) are not
+picklable.
 """
 
 from __future__ import annotations

--- a/python/tablers/__init__.py
+++ b/python/tablers/__init__.py
@@ -23,6 +23,19 @@ Notes
 -----
 The library automatically loads the appropriate Pdfium library
 based on the operating system (Windows, Linux, or macOS).
+
+**Thread Safety**: This library is NOT thread-safe. A global
+``PDFIUM_RT`` is created at import time and is bound to the
+importing thread. All ``Document`` operations must run on that
+same thread. Using ``Document`` from a different thread will
+raise a ``PanicException``. In multi-threaded environments,
+import and use this library within the same worker thread, or
+use ``multiprocessing`` instead of ``threading``.
+
+Although `pdfium-render <https://github.com/ajrcarey/pdfium-render#multi-threading>`_
+offers a ``thread_safe`` compile-time feature (mutex-based locking),
+enabling it would introduce performance overhead in single-threaded
+use, so tablers does not enable it.
 """
 
 from __future__ import annotations
@@ -357,6 +370,11 @@ class Document:
     -----
     Either `path` or `bytes` must be provided, but not both.
     Always close the document when done to release resources.
+
+    **Thread Safety**: This class is NOT thread-safe. All
+    operations must be performed on the same thread that
+    imported the ``tablers`` module. Using it from a different
+    thread will raise a ``PanicException``.
     """
 
     _stream: bytes | None  # type hint only; instance value set in __init__

--- a/src/edges.rs
+++ b/src/edges.rs
@@ -413,7 +413,7 @@ pub(crate) fn merge_edges(
 ///
 /// An edge can be either horizontal or vertical and includes
 /// position, width, and color information.
-#[pyclass(from_py_object)]
+#[pyclass(module = "tablers.tablers", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct Edge {
     /// The orientation of the edge (horizontal or vertical).
@@ -560,6 +560,36 @@ impl Edge {
         } else {
             false
         }
+    }
+
+    /// Pickle support: serialize to plain Python types.
+    ///
+    /// Returns `(cls, (orientation, x1, y1, x2, y2, width, color))`
+    /// so pickle calls the existing `#[new]` constructor on unpickle.
+    fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<Py<PyAny>> {
+        let module = py.import("tablers.tablers")?;
+        let cls = module.getattr("Edge")?;
+        let orientation_str: &str = match self.orientation {
+            Orientation::Horizontal => "h",
+            Orientation::Vertical => "v",
+        };
+        let color = color_to_py(&self.color);
+        // Return (cls, args_tuple) — pickle calls cls(*args_tuple)
+        Ok((
+            cls,
+            (
+                orientation_str,
+                self.x1.into_inner(),
+                self.y1.into_inner(),
+                self.x2.into_inner(),
+                self.y2.into_inner(),
+                self.width.into_inner(),
+                color,
+            ),
+        )
+            .into_pyobject(py)?
+            .into_any()
+            .unbind())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ mod words;
 ///
 /// This struct holds the Pdfium instance and provides methods to interact with PDF documents.
 /// It is unsendable because the underlying Pdfium library is not thread-safe.
-#[pyclass(unsendable)]
+#[pyclass(module = "tablers.tablers", unsendable)]
 pub struct PdfiumRuntime {
     inner: Rc<Pdfium>,
 }
@@ -263,7 +263,7 @@ struct DocumentInner {
 ///
 /// This struct provides methods to access pages and metadata of a PDF document.
 /// The document can be closed explicitly, after which all operations will fail.
-#[pyclass(unsendable)]
+#[pyclass(module = "tablers.tablers", unsendable)]
 pub struct Pyo3Doc {
     inner: Rc<RefCell<DocumentInner>>,
 }
@@ -501,7 +501,7 @@ impl Pyo3Doc {
 /// Iterator for traversing pages in a PDF document.
 ///
 /// This iterator is memory-efficient for large PDFs as it loads pages on demand.
-#[pyclass(unsendable, name = "PageIterator")]
+#[pyclass(module = "tablers.tablers", unsendable, name = "PageIterator")]
 pub struct PyPageIterator {
     doc_inner: Rc<RefCell<DocumentInner>>,
     current_idx: usize,
@@ -543,7 +543,7 @@ impl PyPageIterator {
 ///
 /// Provides access to page properties like dimensions and rotation,
 /// as well as methods to extract objects and text from the page.
-#[pyclass(unsendable, name = "Pyo3Page")]
+#[pyclass(module = "tablers.tablers", unsendable, name = "Pyo3Page")]
 pub struct Pyo3Page {
     doc_inner: Rc<RefCell<DocumentInner>>,
     inner: Page,

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -2,8 +2,22 @@ use ordered_float::OrderedFloat;
 use pdfium_render::prelude::{PdfColor, PdfPathFillMode, PdfPathSegmentType};
 use pyo3::prelude::*;
 
+/// Parses a fill mode string back to PdfPathFillMode, returning an error for unrecognized values.
+/// Used by pickle deserialization to detect corrupted data instead of silently defaulting.
+fn parse_fill_mode(name: &str) -> PyResult<PdfPathFillMode> {
+    match name {
+        "NONE" => Ok(PdfPathFillMode::None),
+        "WINDING" => Ok(PdfPathFillMode::Winding),
+        "EVEN_ODD" => Ok(PdfPathFillMode::EvenOdd),
+        _ => Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "Invalid FillMode: {}",
+            name
+        ))),
+    }
+}
+
 /// PDF path fill rule: mirrors pdfium-render's PdfPathFillMode for Python exposure.
-#[pyclass(from_py_object)]
+#[pyclass(module = "tablers.tablers", from_py_object)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
 #[allow(clippy::upper_case_acronyms)]
@@ -26,10 +40,41 @@ impl From<PdfPathFillMode> for FillMode {
     }
 }
 
+#[pymethods]
+impl FillMode {
+    fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<Py<PyAny>> {
+        let module = py.import("tablers.tablers")?;
+        let cls = module.getattr("FillMode")?;
+        let name = match self {
+            FillMode::NONE => "NONE",
+            FillMode::WINDING => "WINDING",
+            FillMode::EVEN_ODD => "EVEN_ODD",
+        };
+        Ok((cls.getattr("_from_pickle")?, (name.to_string(),))
+            .into_pyobject(py)?
+            .into_any()
+            .unbind())
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "_from_pickle")]
+    fn py_from_pickle(name: &str) -> PyResult<Self> {
+        match name {
+            "NONE" => Ok(FillMode::NONE),
+            "WINDING" => Ok(FillMode::WINDING),
+            "EVEN_ODD" => Ok(FillMode::EVEN_ODD),
+            _ => Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "Invalid FillMode: {}",
+                name
+            ))),
+        }
+    }
+}
+
 /// Container for all extracted objects from a PDF page.
 ///
 /// This struct holds all rectangles, lines, and characters found in a page.
-#[pyclass(from_py_object)]
+#[pyclass(module = "tablers.tablers", from_py_object)]
 #[derive(Clone)]
 pub struct Objects {
     /// All rectangles found in the page.
@@ -41,6 +86,31 @@ pub struct Objects {
     /// All text characters found in the page.
     #[pyo3(get)]
     pub chars: Vec<Char>,
+}
+
+#[pymethods]
+impl Objects {
+    fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<Py<PyAny>> {
+        let module = py.import("tablers.tablers")?;
+        let cls = module.getattr("Objects")?;
+        Ok((
+            cls.getattr("_from_pickle")?,
+            (self.rects.clone(), self.lines.clone(), self.chars.clone()),
+        )
+            .into_pyobject(py)?
+            .into_any()
+            .unbind())
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "_from_pickle")]
+    fn py_from_pickle(rects: Vec<Rect>, lines: Vec<Line>, chars: Vec<Char>) -> Self {
+        Objects {
+            rects,
+            lines,
+            chars,
+        }
+    }
 }
 
 /// A 2D point represented as (x, y) coordinates.
@@ -61,10 +131,36 @@ pub type BboxKey = (
     OrderedFloat<f32>,
     OrderedFloat<f32>,
 );
+
+/// Converts a `BboxKey` to a plain Python-compatible tuple.
+pub(crate) fn bbox_to_py(bbox: &BboxKey) -> PyBbox {
+    (
+        bbox.0.into_inner(),
+        bbox.1.into_inner(),
+        bbox.2.into_inner(),
+        bbox.3.into_inner(),
+    )
+}
+
+/// Converts a plain Python tuple back to a `BboxKey`.
+pub(crate) fn bbox_from_py(b: &PyBbox) -> BboxKey {
+    (
+        OrderedFloat(b.0),
+        OrderedFloat(b.1),
+        OrderedFloat(b.2),
+        OrderedFloat(b.3),
+    )
+}
+
+/// Converts a `PdfColor` to a plain Python-compatible RGBA tuple.
+pub(crate) fn color_to_py(color: &PdfColor) -> PyColor {
+    (color.red(), color.green(), color.blue(), color.alpha())
+}
+
 /// Represents a rectangle extracted from a PDF page.
 ///
 /// Rectangles are typically used as table cell borders or backgrounds.
-#[pyclass(from_py_object)]
+#[pyclass(module = "tablers.tablers", from_py_object)]
 #[derive(Clone)]
 pub struct Rect {
     /// The bounding box of the rectangle.
@@ -123,12 +219,66 @@ impl Rect {
     fn fill_mode(&self) -> FillMode {
         self.fill_mode.into()
     }
+
+    /// Pickle support.
+    fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<Py<PyAny>> {
+        let module = py.import("tablers.tablers")?;
+        let cls = module.getattr("Rect")?;
+        let bbox = bbox_to_py(&self.bbox);
+        let fill_color = color_to_py(&self.fill_color);
+        let stroke_color = color_to_py(&self.stroke_color);
+        let fill_mode_name = match self.fill_mode {
+            PdfPathFillMode::None => "NONE",
+            PdfPathFillMode::Winding => "WINDING",
+            PdfPathFillMode::EvenOdd => "EVEN_ODD",
+        };
+        Ok((
+            cls.getattr("_from_pickle")?,
+            (
+                bbox,
+                fill_color,
+                stroke_color,
+                self.stroke_width,
+                self.is_stroked,
+                fill_mode_name.to_string(),
+            ),
+        )
+            .into_pyobject(py)?
+            .into_any()
+            .unbind())
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "_from_pickle")]
+    fn py_from_pickle(
+        bbox: PyBbox,
+        fill_color: PyColor,
+        stroke_color: PyColor,
+        stroke_width: f32,
+        is_stroked: bool,
+        fill_mode: String,
+    ) -> PyResult<Self> {
+        let fill_mode = parse_fill_mode(&fill_mode)?;
+        Ok(Rect {
+            bbox: bbox_from_py(&bbox),
+            fill_color: PdfColor::new(fill_color.0, fill_color.1, fill_color.2, fill_color.3),
+            stroke_color: PdfColor::new(
+                stroke_color.0,
+                stroke_color.1,
+                stroke_color.2,
+                stroke_color.3,
+            ),
+            stroke_width,
+            is_stroked,
+            fill_mode,
+        })
+    }
 }
 
 /// Represents a line segment extracted from a PDF page.
 ///
 /// Lines can be straight or curved and are used for table borders.
-#[pyclass(from_py_object)]
+#[pyclass(module = "tablers.tablers", from_py_object)]
 #[derive(Clone)]
 pub struct Line {
     /// The type of line (straight or curve).
@@ -202,16 +352,90 @@ impl Line {
     fn fill_mode(&self) -> FillMode {
         self.fill_mode.into()
     }
+
+    /// Pickle support.
+    fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<Py<PyAny>> {
+        let module = py.import("tablers.tablers")?;
+        let cls = module.getattr("Line")?;
+        let line_type_str = match self.line_type {
+            LineType::Straight => "straight",
+            LineType::Polyline => "polyline",
+            LineType::Curve => "curve",
+        };
+        let points: Vec<PyPoint> = self
+            .points
+            .iter()
+            .map(|p| (p.0.into_inner(), p.1.into_inner()))
+            .collect();
+        let stroke_color = color_to_py(&self.stroke_color);
+        let fill_color = color_to_py(&self.fill_color);
+        let fill_mode_name = match self.fill_mode {
+            PdfPathFillMode::None => "NONE",
+            PdfPathFillMode::Winding => "WINDING",
+            PdfPathFillMode::EvenOdd => "EVEN_ODD",
+        };
+        Ok((
+            cls.getattr("_from_pickle")?,
+            (
+                line_type_str.to_string(),
+                points,
+                stroke_color,
+                fill_color,
+                self.width.into_inner(),
+                self.is_stroked,
+                fill_mode_name.to_string(),
+            ),
+        )
+            .into_pyobject(py)?
+            .into_any()
+            .unbind())
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "_from_pickle")]
+    fn py_from_pickle(
+        line_type: String,
+        points: Vec<PyPoint>,
+        stroke_color: PyColor,
+        fill_color: PyColor,
+        width: f32,
+        is_stroked: bool,
+        fill_mode: String,
+    ) -> PyResult<Self> {
+        let line_type = match line_type.as_str() {
+            "polyline" => LineType::Polyline,
+            "curve" => LineType::Curve,
+            _ => LineType::Straight,
+        };
+        let fill_mode = parse_fill_mode(&fill_mode)?;
+        Ok(Line {
+            line_type,
+            points: points
+                .into_iter()
+                .map(|(x, y)| (OrderedFloat(x), OrderedFloat(y)))
+                .collect(),
+            stroke_color: PdfColor::new(
+                stroke_color.0,
+                stroke_color.1,
+                stroke_color.2,
+                stroke_color.3,
+            ),
+            fill_color: PdfColor::new(fill_color.0, fill_color.1, fill_color.2, fill_color.3),
+            width: OrderedFloat(width),
+            is_stroked,
+            fill_mode,
+        })
+    }
 }
 
 /// Represents a text character extracted from a PDF page.
 ///
 /// Each character includes its Unicode value, position, and rotation information.
-/// `unicode_char` is derived from Pdfium’s UTF-16 `unicode_value()` with surrogate-pair merging
+/// `unicode_char` is derived from Pdfium's UTF-16 `unicode_value()` with surrogate-pair merging
 /// (one logical scalar per glyph where possible). See PDFium
 /// [`public/fpdf_text.h` (main)](https://pdfium.googlesource.com/pdfium/+/refs/heads/main/public/fpdf_text.h)
 /// for the UCS-2 / UTF-16 text APIs (`FPDFText_GetText`, `FPDFText_GetBoundedText`, etc.).
-#[pyclass(from_py_object)]
+#[pyclass(module = "tablers.tablers", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct Char {
     /// The Unicode string for this logical character (UTF-16 code units merged per
@@ -243,6 +467,41 @@ impl Char {
     #[getter]
     fn rotation_degrees(&self) -> f32 {
         self.rotation_degrees.into_inner()
+    }
+
+    /// Pickle support.
+    fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<Py<PyAny>> {
+        let module = py.import("tablers.tablers")?;
+        let cls = module.getattr("Char")?;
+        let bbox = bbox_to_py(&self.bbox);
+        Ok((
+            cls.getattr("_from_pickle")?,
+            (
+                self.unicode_char.clone(),
+                bbox,
+                self.rotation_degrees.into_inner(),
+                self.upright,
+            ),
+        )
+            .into_pyobject(py)?
+            .into_any()
+            .unbind())
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "_from_pickle")]
+    fn py_from_pickle(
+        unicode_char: Option<String>,
+        bbox: PyBbox,
+        rotation_degrees: f32,
+        upright: bool,
+    ) -> Self {
+        Char {
+            unicode_char,
+            bbox: bbox_from_py(&bbox),
+            rotation_degrees: OrderedFloat(rotation_degrees),
+            upright,
+        }
     }
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -155,7 +155,7 @@ impl BitAnd<StrategyType> for StrategyType {
 /// Controls how edges are detected, snapped, joined, and how intersections
 /// are identified when finding tables in a PDF page.
 #[derive(Debug, Clone)]
-#[pyclass(from_py_object)]
+#[pyclass(module = "tablers.tablers", from_py_object)]
 pub struct TfSettings {
     /// Strategy for detecting vertical edges.
     pub vertical_strategy: StrategyType,
@@ -273,6 +273,21 @@ impl TfSettings {
             "text" => StrategyType::Text,
             "explicit" => StrategyType::Explicit,
             _ => panic!("Invalid strategy: {}", strategy_str),
+        }
+    }
+
+    /// Same as `strategy_str_to_enum` but returns a `PyResult` instead of panicking.
+    /// Used by pickle deserialization to handle potentially corrupted data gracefully.
+    fn strategy_str_to_enum_checked(strategy_str: &str) -> PyResult<StrategyType> {
+        match strategy_str {
+            "lines" => Ok(StrategyType::Lines),
+            "lines_strict" => Ok(StrategyType::LinesStrict),
+            "text" => Ok(StrategyType::Text),
+            "explicit" => Ok(StrategyType::Explicit),
+            _ => Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "Invalid strategy: {}",
+                strategy_str
+            ))),
         }
     }
 
@@ -823,6 +838,150 @@ impl TfSettings {
             false
         }
     }
+
+    /// Pickle support.
+    fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<Py<PyAny>> {
+        let module = py.import("tablers.tablers")?;
+        let cls = module.getattr("TfSettings")?;
+        let text_settings_state = (
+            self.text_settings.x_tolerance.into_inner(),
+            self.text_settings.y_tolerance.into_inner(),
+            self.text_settings.keep_blank_chars,
+            self.text_settings.use_text_flow,
+            self.text_settings.text_read_in_clockwise,
+            self.text_settings.split_punctuation_to_str(),
+            self.text_settings.expand_ligatures,
+            self.text_settings.need_strip,
+        );
+        // Split into two sub-tuples to stay within into_pyobject's tuple limit
+        let part1 = (
+            Self::strategy_enum_to_str(self.vertical_strategy).to_string(),
+            Self::strategy_enum_to_str(self.horizontal_strategy).to_string(),
+            self.snap_x_tolerance.into_inner(),
+            self.snap_y_tolerance.into_inner(),
+            self.join_x_tolerance.into_inner(),
+            self.join_y_tolerance.into_inner(),
+            self.edge_min_length.into_inner(),
+            self.edge_min_length_prefilter.into_inner(),
+            self.min_words_vertical,
+            self.min_words_horizontal,
+            self.intersection_x_tolerance.into_inner(),
+            self.intersection_y_tolerance.into_inner(),
+        );
+        let part2 = (
+            self.include_single_cell,
+            self.min_rows,
+            self.min_columns,
+            text_settings_state,
+            self.explicit_h_edges.clone(),
+            self.explicit_v_edges.clone(),
+            self.exclude_background_colored_edges,
+            self.close_unclosed_boundaries,
+        );
+        Ok((cls.getattr("_from_pickle")?, (part1, part2))
+            .into_pyobject(py)?
+            .into_any()
+            .unbind())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::type_complexity)]
+    #[staticmethod]
+    #[pyo3(name = "_from_pickle")]
+    fn py_from_pickle(
+        part1: (
+            String,
+            String,
+            f32,
+            f32,
+            f32,
+            f32,
+            f32,
+            f32,
+            usize,
+            usize,
+            f32,
+            f32,
+        ),
+        part2: (
+            bool,
+            Option<usize>,
+            Option<usize>,
+            (f32, f32, bool, bool, bool, Option<String>, bool, bool),
+            Option<Vec<Edge>>,
+            Option<Vec<Edge>>,
+            bool,
+            bool,
+        ),
+    ) -> PyResult<Self> {
+        let (
+            vertical_strategy,
+            horizontal_strategy,
+            snap_x_tolerance,
+            snap_y_tolerance,
+            join_x_tolerance,
+            join_y_tolerance,
+            edge_min_length,
+            edge_min_length_prefilter,
+            min_words_vertical,
+            min_words_horizontal,
+            intersection_x_tolerance,
+            intersection_y_tolerance,
+        ) = part1;
+        let (
+            include_single_cell,
+            min_rows,
+            min_columns,
+            text_settings_state,
+            explicit_h_edges,
+            explicit_v_edges,
+            exclude_background_colored_edges,
+            close_unclosed_boundaries,
+        ) = part2;
+        let ts = text_settings_state;
+        Ok(TfSettings {
+            vertical_strategy: Self::strategy_str_to_enum_checked(&vertical_strategy)?,
+            horizontal_strategy: Self::strategy_str_to_enum_checked(&horizontal_strategy)?,
+            snap_x_tolerance: NonNegativeF32::new(snap_x_tolerance, "snap_x_tolerance")?,
+            snap_y_tolerance: NonNegativeF32::new(snap_y_tolerance, "snap_y_tolerance")?,
+            join_x_tolerance: NonNegativeF32::new(join_x_tolerance, "join_x_tolerance")?,
+            join_y_tolerance: NonNegativeF32::new(join_y_tolerance, "join_y_tolerance")?,
+            edge_min_length: NonNegativeF32::new(edge_min_length, "edge_min_length")?,
+            edge_min_length_prefilter: NonNegativeF32::new(
+                edge_min_length_prefilter,
+                "edge_min_length_prefilter",
+            )?,
+            min_words_vertical,
+            min_words_horizontal,
+            intersection_x_tolerance: NonNegativeF32::new(
+                intersection_x_tolerance,
+                "intersection_x_tolerance",
+            )?,
+            intersection_y_tolerance: NonNegativeF32::new(
+                intersection_y_tolerance,
+                "intersection_y_tolerance",
+            )?,
+            include_single_cell,
+            min_rows,
+            min_columns,
+            text_settings: WordsExtractSettings {
+                x_tolerance: NonNegativeF32::new(ts.0, "x_tolerance")?,
+                y_tolerance: NonNegativeF32::new(ts.1, "y_tolerance")?,
+                keep_blank_chars: ts.2,
+                use_text_flow: ts.3,
+                text_read_in_clockwise: ts.4,
+                split_at_punctuation: WordsExtractSettings::str_to_split_punctuation(
+                    ts.5.as_deref(),
+                ),
+                expand_ligatures: ts.6,
+                need_strip: ts.7,
+            },
+            explicit_h_edges,
+            explicit_v_edges,
+            exclude_background_colored_edges,
+            close_unclosed_boundaries,
+        })
+    }
 }
 
 /// Specifies how to split words at punctuation characters.
@@ -839,7 +998,7 @@ pub enum SplitPunctuation {
 /// Controls how characters are grouped into words, including
 /// tolerance values and text direction handling.
 #[derive(Debug, Clone)]
-#[pyclass(from_py_object)]
+#[pyclass(module = "tablers.tablers", from_py_object)]
 pub struct WordsExtractSettings {
     /// X-axis tolerance for grouping characters into words.
     pub x_tolerance: NonNegativeF32,
@@ -1064,6 +1223,54 @@ impl WordsExtractSettings {
         } else {
             false
         }
+    }
+
+    /// Pickle support.
+    fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<Py<PyAny>> {
+        let module = py.import("tablers.tablers")?;
+        let cls = module.getattr("WordsExtractSettings")?;
+        let split = self.split_punctuation_to_str();
+        Ok((
+            cls.getattr("_from_pickle")?,
+            (
+                self.x_tolerance.into_inner(),
+                self.y_tolerance.into_inner(),
+                self.keep_blank_chars,
+                self.use_text_flow,
+                self.text_read_in_clockwise,
+                split,
+                self.expand_ligatures,
+                self.need_strip,
+            ),
+        )
+            .into_pyobject(py)?
+            .into_any()
+            .unbind())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[staticmethod]
+    #[pyo3(name = "_from_pickle")]
+    fn py_from_pickle(
+        x_tolerance: f32,
+        y_tolerance: f32,
+        keep_blank_chars: bool,
+        use_text_flow: bool,
+        text_read_in_clockwise: bool,
+        split_at_punctuation: Option<String>,
+        expand_ligatures: bool,
+        need_strip: bool,
+    ) -> PyResult<Self> {
+        Ok(WordsExtractSettings {
+            x_tolerance: NonNegativeF32::new(x_tolerance, "x_tolerance")?,
+            y_tolerance: NonNegativeF32::new(y_tolerance, "y_tolerance")?,
+            keep_blank_chars,
+            use_text_flow,
+            text_read_in_clockwise,
+            split_at_punctuation: Self::str_to_split_punctuation(split_at_punctuation.as_deref()),
+            expand_ligatures,
+            need_strip,
+        })
     }
 }
 

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -72,7 +72,7 @@ impl<'tab> CellGroup<'tab> {
 }
 
 /// An owned version of CellGroup for Python interop.
-#[pyclass(name = "CellGroup", from_py_object)]
+#[pyclass(module = "tablers.tablers", name = "CellGroup", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct PyCellGroup {
     /// The cells in this group, with `None` for empty positions.
@@ -92,6 +92,44 @@ impl PyCellGroup {
             self.bbox.2.into_inner(),
             self.bbox.3.into_inner(),
         )
+    }
+
+    /// Pickle support.
+    fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<Py<PyAny>> {
+        let module = py.import("tablers.tablers")?;
+        let cls = module.getattr("CellGroup")?;
+        let cells_state: Vec<Option<(String, PyBbox)>> = self
+            .cells
+            .iter()
+            .map(|c| {
+                c.as_ref()
+                    .map(|cell| (cell.text.clone(), bbox_to_py(&cell.bbox)))
+            })
+            .collect();
+        let bbox = bbox_to_py(&self.bbox);
+        Ok((cls.getattr("_from_pickle")?, (cells_state, bbox))
+            .into_pyobject(py)?
+            .into_any()
+            .unbind())
+    }
+
+    /// Reconstruct from pickled state.
+    #[staticmethod]
+    #[pyo3(name = "_from_pickle")]
+    fn py_from_pickle(cells_state: Vec<Option<(String, PyBbox)>>, bbox: PyBbox) -> Self {
+        let cells: Vec<Option<TableCell>> = cells_state
+            .into_iter()
+            .map(|c| {
+                c.map(|(text, b)| TableCell {
+                    text,
+                    bbox: bbox_from_py(&b),
+                })
+            })
+            .collect();
+        PyCellGroup {
+            cells,
+            bbox: bbox_from_py(&bbox),
+        }
     }
 }
 
@@ -187,7 +225,7 @@ fn get_axis_value(cell: &BboxKey, axis: usize) -> OrderedFloat<f32> {
 /// Represents a single cell in a table.
 ///
 /// Each cell has a bounding box and optional text content.
-#[pyclass(from_py_object)]
+#[pyclass(module = "tablers.tablers", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct TableCell {
     /// The text content of the cell.
@@ -214,6 +252,27 @@ impl TableCell {
             self.bbox.3.into_inner(),
         )
     }
+
+    /// Pickle support.
+    fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<Py<PyAny>> {
+        let module = py.import("tablers.tablers")?;
+        let cls = module.getattr("TableCell")?;
+        let bbox = bbox_to_py(&self.bbox);
+        Ok((cls.getattr("_from_pickle")?, (self.text.clone(), bbox))
+            .into_pyobject(py)?
+            .into_any()
+            .unbind())
+    }
+
+    /// Reconstruct from pickled state.
+    #[staticmethod]
+    #[pyo3(name = "_from_pickle")]
+    fn py_from_pickle(text: String, bbox: PyBbox) -> Self {
+        TableCell {
+            text,
+            bbox: bbox_from_py(&bbox),
+        }
+    }
 }
 
 /// Value of one grid slot: either text (top-left of a cell) or merge info.
@@ -226,7 +285,7 @@ pub struct TableCellValue {
 }
 
 /// Python-exposed TableCellValue for to_list().
-#[pyclass(name = "TableCellValue", from_py_object)]
+#[pyclass(module = "tablers.tablers", name = "TableCellValue", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct PyTableCellValue {
     #[pyo3(get)]
@@ -253,6 +312,30 @@ impl PyTableCellValue {
     fn __repr__(&self) -> String {
         py_table_cell_value_repr(&self.text, self.merged_left, self.merged_top)
     }
+
+    /// Pickle support.
+    fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<Py<PyAny>> {
+        let module = py.import("tablers.tablers")?;
+        let cls = module.getattr("TableCellValue")?;
+        Ok((
+            cls.getattr("_from_pickle")?,
+            (self.text.clone(), self.merged_left, self.merged_top),
+        )
+            .into_pyobject(py)?
+            .into_any()
+            .unbind())
+    }
+
+    /// Reconstruct from pickled state.
+    #[staticmethod]
+    #[pyo3(name = "_from_pickle")]
+    fn py_from_pickle(text: Option<String>, merged_left: bool, merged_top: bool) -> Self {
+        PyTableCellValue {
+            text,
+            merged_left,
+            merged_top,
+        }
+    }
 }
 
 /// Returns true if point (x, y) is inside bbox (x1 <= x < x2, y1 <= y < y2).
@@ -271,7 +354,7 @@ fn float_eq(a: OrderedFloat<f32>, b: OrderedFloat<f32>) -> bool {
 /// Represents a table extracted from a PDF page.
 ///
 /// A table consists of cells organized in a grid structure.
-#[pyclass]
+#[pyclass(module = "tablers.tablers")]
 pub struct Table {
     /// All cells in the table.
     pub cells: Vec<TableCell>,
@@ -389,6 +472,50 @@ impl Table {
                     .collect()
             })
             .map_err(pyo3::exceptions::PyValueError::new_err)
+    }
+
+    /// Pickle support: serialize all fields as plain Python types.
+    fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<Py<PyAny>> {
+        let module = py.import("tablers.tablers")?;
+        let cls = module.getattr("Table")?;
+        // Serialize cells as (text, bbox) tuples
+        let cells_state: Vec<(String, PyBbox)> = self
+            .cells
+            .iter()
+            .map(|c| (c.text.clone(), bbox_to_py(&c.bbox)))
+            .collect();
+        let bbox = bbox_to_py(&self.bbox);
+        Ok((
+            cls.getattr("_from_pickle")?,
+            (cells_state, bbox, self.page_index, self.text_extracted),
+        )
+            .into_pyobject(py)?
+            .into_any()
+            .unbind())
+    }
+
+    /// Reconstruct a Table from pickled state.
+    #[staticmethod]
+    #[pyo3(name = "_from_pickle")]
+    fn py_from_pickle(
+        cells_state: Vec<(String, PyBbox)>,
+        bbox: PyBbox,
+        page_index: usize,
+        text_extracted: bool,
+    ) -> Self {
+        let cells: Vec<TableCell> = cells_state
+            .into_iter()
+            .map(|(text, b)| TableCell {
+                text,
+                bbox: bbox_from_py(&b),
+            })
+            .collect();
+        Table {
+            cells,
+            bbox: bbox_from_py(&bbox),
+            page_index,
+            text_extracted,
+        }
     }
 }
 

--- a/tests/python/test_pickle.py
+++ b/tests/python/test_pickle.py
@@ -1,0 +1,323 @@
+"""Tests for pickle support of PyO3 data objects."""
+
+import pickle
+
+import pytest
+from tablers import (
+    Edge,
+    TfSettings,
+    WordsExtractSettings,
+    find_tables,
+)
+from tablers.tablers import FillMode
+
+
+class TestEdgePickle:
+    def test_pickle_round_trip(self):
+        edge = Edge("h", 10.0, 20.0, 30.0, 40.0, width=2.0, color=(255, 0, 0, 128))
+        restored = pickle.loads(pickle.dumps(edge))
+        assert restored.orientation == "h"
+        assert restored.x1 == 10.0
+        assert restored.y1 == 20.0
+        assert restored.x2 == 30.0
+        assert restored.y2 == 40.0
+        assert restored.width == 2.0
+        assert restored.color == (255, 0, 0, 128)
+
+    def test_pickle_vertical_edge(self):
+        edge = Edge("v", 5.0, 10.0, 5.0, 50.0)
+        restored = pickle.loads(pickle.dumps(edge))
+        assert restored.orientation == "v"
+        assert restored.x1 == 5.0
+        assert restored.y1 == 10.0
+
+    def test_pickle_default_edge(self):
+        edge = Edge("h", 0.0, 0.0, 100.0, 0.0)
+        restored = pickle.loads(pickle.dumps(edge))
+        assert restored.width == 1.0
+        assert restored.color == (0, 0, 0, 255)
+
+
+class TestTableCellPickle:
+    def test_pickle_from_extracted_table(self, edge_test_doc):
+        tables = find_tables(edge_test_doc.get_page(0), extract_text=True)
+        if not tables:
+            pytest.skip("No tables found")
+        cell = tables[0].cells[0]
+        restored = pickle.loads(pickle.dumps(cell))
+        assert restored.text == cell.text
+        assert restored.bbox == cell.bbox
+
+
+class TestTablePickle:
+    def test_pickle_table_no_text(self, edge_test_doc):
+        tables = find_tables(edge_test_doc.get_page(0), extract_text=False)
+        if not tables:
+            pytest.skip("No tables found")
+        table = tables[0]
+        restored = pickle.loads(pickle.dumps(table))
+        assert restored.bbox == table.bbox
+        assert len(restored.cells) == len(table.cells)
+        assert restored.page_index == table.page_index
+        assert restored.text_extracted == table.text_extracted
+
+    def test_pickle_table_with_text(self, multiple_move_to_in_one_seg_doc):
+        tables = find_tables(multiple_move_to_in_one_seg_doc.get_page(0), extract_text=True)
+        assert len(tables) == 1
+        table = tables[0]
+        restored = pickle.loads(pickle.dumps(table))
+        assert restored.bbox == table.bbox
+        assert len(restored.cells) == len(table.cells)
+        assert restored.text_extracted is True
+        for orig, rest in zip(table.cells, restored.cells, strict=True):
+            assert orig.text == rest.text
+            assert orig.bbox == rest.bbox
+
+    def test_pickle_table_then_to_csv(self, multiple_move_to_in_one_seg_doc):
+        """A pickled+unpickled table should still produce correct to_csv()."""
+        tables = find_tables(multiple_move_to_in_one_seg_doc.get_page(0), extract_text=True)
+        table = tables[0]
+        restored = pickle.loads(pickle.dumps(table))
+        assert restored.to_csv() == table.to_csv()
+
+    def test_pickle_list_of_tables(self, edge_test_doc):
+        """A list of tables should be picklable."""
+        tables = find_tables(edge_test_doc.get_page(0), extract_text=True)
+        restored_list = pickle.loads(pickle.dumps(tables))
+        assert len(restored_list) == len(tables)
+        for orig, rest in zip(tables, restored_list, strict=True):
+            assert orig.bbox == rest.bbox
+            assert len(orig.cells) == len(rest.cells)
+
+
+class TestPyTableCellValuePickle:
+    def test_pickle_from_to_list(self, multiple_move_to_in_one_seg_doc):
+        tables = find_tables(multiple_move_to_in_one_seg_doc.get_page(0), extract_text=True)
+        rows = tables[0].to_list()
+        for row in rows:
+            for cell in row:
+                restored = pickle.loads(pickle.dumps(cell))
+                assert restored.text == cell.text
+                assert restored.merged_left == cell.merged_left
+                assert restored.merged_top == cell.merged_top
+
+
+class TestPyCellGroupPickle:
+    def test_pickle_rows(self, edge_test_doc):
+        tables = find_tables(edge_test_doc.get_page(0), extract_text=True)
+        if not tables:
+            pytest.skip("No tables found")
+        table = tables[0]
+        rows = table.rows
+        for row in rows:
+            restored = pickle.loads(pickle.dumps(row))
+            assert restored.bbox == row.bbox
+            assert len(restored.cells) == len(row.cells)
+
+
+class TestCharPickle:
+    def test_pickle_from_objects(self, edge_test_doc):
+        page = edge_test_doc.get_page(0)
+        page.extract_objects()
+        objects = page.objects
+        if not objects or not objects.chars:
+            pytest.skip("Need chars")
+        char = objects.chars[0]
+        restored = pickle.loads(pickle.dumps(char))
+        assert restored.unicode_char == char.unicode_char
+        assert restored.bbox == char.bbox
+        assert restored.rotation_degrees == char.rotation_degrees
+        assert restored.upright == char.upright
+
+
+class TestRectPickle:
+    def test_pickle_from_objects(self, edge_test_doc):
+        page = edge_test_doc.get_page(0)
+        page.extract_objects()
+        objects = page.objects
+        if not objects or not objects.rects:
+            pytest.skip("Need rects")
+        rect = objects.rects[0]
+        restored = pickle.loads(pickle.dumps(rect))
+        assert restored.bbox == rect.bbox
+        assert restored.fill_color == rect.fill_color
+        assert restored.stroke_color == rect.stroke_color
+        assert restored.stroke_width == rect.stroke_width
+        assert restored.is_stroked == rect.is_stroked
+        assert restored.fill_mode == rect.fill_mode
+
+
+class TestLinePickle:
+    def test_pickle_from_objects(self, edge_test_doc):
+        page = edge_test_doc.get_page(0)
+        page.extract_objects()
+        objects = page.objects
+        if not objects or not objects.lines:
+            pytest.skip("Need lines")
+        line = objects.lines[0]
+        restored = pickle.loads(pickle.dumps(line))
+        assert restored.line_type == line.line_type
+        assert restored.points == line.points
+        assert restored.stroke_color == line.stroke_color
+        assert restored.fill_color == line.fill_color
+        assert restored.width == line.width
+        assert restored.is_stroked == line.is_stroked
+        assert restored.fill_mode == line.fill_mode
+
+
+class TestObjectsPickle:
+    def test_pickle_objects(self, edge_test_doc):
+        page = edge_test_doc.get_page(0)
+        page.extract_objects()
+        objects = page.objects
+        if not objects:
+            pytest.skip("Need objects")
+        restored = pickle.loads(pickle.dumps(objects))
+        assert len(restored.rects) == len(objects.rects)
+        assert len(restored.lines) == len(objects.lines)
+        assert len(restored.chars) == len(objects.chars)
+
+
+class TestFillModePickle:
+    def test_pickle_fill_mode_values(self):
+        for val in [FillMode.NONE, FillMode.WINDING, FillMode.EVEN_ODD]:
+            restored = pickle.loads(pickle.dumps(val))
+            assert restored == val
+
+
+class TestWordsExtractSettingsPickle:
+    def test_pickle_default(self):
+        s = WordsExtractSettings()
+        restored = pickle.loads(pickle.dumps(s))
+        assert restored.x_tolerance == s.x_tolerance
+        assert restored.y_tolerance == s.y_tolerance
+        assert restored.keep_blank_chars == s.keep_blank_chars
+        assert restored.use_text_flow == s.use_text_flow
+        assert restored.text_read_in_clockwise == s.text_read_in_clockwise
+        assert restored.split_at_punctuation == s.split_at_punctuation
+        assert restored.expand_ligatures == s.expand_ligatures
+        assert restored.need_strip == s.need_strip
+
+    def test_pickle_custom(self):
+        s = WordsExtractSettings(
+            x_tolerance=5.0,
+            y_tolerance=10.0,
+            keep_blank_chars=True,
+            split_at_punctuation="all",
+            need_strip=False,
+        )
+        restored = pickle.loads(pickle.dumps(s))
+        assert restored.x_tolerance == 5.0
+        assert restored.y_tolerance == 10.0
+        assert restored.keep_blank_chars is True
+        assert restored.split_at_punctuation == "all"
+        assert restored.need_strip is False
+
+
+class TestTfSettingsPickle:
+    def test_pickle_default(self):
+        s = TfSettings()
+        restored = pickle.loads(pickle.dumps(s))
+        assert restored.vertical_strategy == s.vertical_strategy
+        assert restored.horizontal_strategy == s.horizontal_strategy
+        assert restored.snap_x_tolerance == s.snap_x_tolerance
+        assert restored.include_single_cell == s.include_single_cell
+
+    def test_pickle_custom(self):
+        s = TfSettings(
+            vertical_strategy="lines",
+            horizontal_strategy="text",
+            snap_x_tolerance=5.0,
+            min_rows=2,
+            min_columns=3,
+            text_split_at_punctuation=".,;",
+        )
+        restored = pickle.loads(pickle.dumps(s))
+        assert restored.vertical_strategy == "lines"
+        assert restored.horizontal_strategy == "text"
+        assert restored.snap_x_tolerance == 5.0
+        assert restored.min_rows == 2
+        assert restored.min_columns == 3
+        assert restored.text_split_at_punctuation == ".,;"
+
+    def test_pickle_with_explicit_edges(self):
+        h_edges = [Edge("h", 0, 0, 100, 0), Edge("h", 0, 50, 100, 50)]
+        v_edges = [Edge("v", 0, 0, 0, 50), Edge("v", 100, 0, 100, 50)]
+        s = TfSettings(
+            horizontal_strategy="explicit",
+            vertical_strategy="explicit",
+            explicit_h_edges=h_edges,
+            explicit_v_edges=v_edges,
+        )
+        restored = pickle.loads(pickle.dumps(s))
+        assert len(restored.explicit_h_edges) == 2
+        assert len(restored.explicit_v_edges) == 2
+
+
+class TestMultiprocessingWithPickle:
+    def test_table_picklable_for_multiprocessing(self, edge_test_doc):
+        """Tables extracted should be directly picklable for multiprocessing."""
+        tables = find_tables(edge_test_doc.get_page(0), extract_text=True)
+        if not tables:
+            pytest.skip("No tables found")
+        for table in tables:
+            data = pickle.dumps(table)
+            restored = pickle.loads(data)
+            assert len(restored.cells) == len(table.cells)
+            assert restored.bbox == table.bbox
+            assert restored.to_csv() == table.to_csv()
+
+    def test_pickle_table_rows_columns(self, edge_test_doc):
+        """Rows and columns should be correct after pickle round-trip."""
+        tables = find_tables(edge_test_doc.get_page(0), extract_text=True)
+        if not tables:
+            pytest.skip("No tables found")
+        table = tables[0]
+        restored = pickle.loads(pickle.dumps(table))
+        assert len(restored.rows) == len(table.rows)
+        assert len(restored.columns) == len(table.columns)
+
+    def test_pickle_table_then_to_list(self, edge_test_doc):
+        """to_list() should produce identical text content after pickle round-trip."""
+        tables = find_tables(edge_test_doc.get_page(0), extract_text=True)
+        if not tables:
+            pytest.skip("No tables found")
+        table = tables[0]
+        restored = pickle.loads(pickle.dumps(table))
+        if table.text_extracted:
+            orig_rows = table.to_list()
+            rest_rows = restored.to_list()
+            assert len(rest_rows) == len(orig_rows)
+            for orig_row, rest_row in zip(orig_rows, rest_rows, strict=True):
+                assert len(rest_row) == len(orig_row)
+                for orig_cell, rest_cell in zip(orig_row, rest_row, strict=True):
+                    assert rest_cell.text == orig_cell.text
+                    assert rest_cell.merged_left == orig_cell.merged_left
+                    assert rest_cell.merged_top == orig_cell.merged_top
+
+
+class TestPickleProtocols:
+    """Verify pickle works across all standard protocol versions."""
+
+    def test_edge_all_protocols(self):
+        edge = Edge("h", 10.0, 20.0, 30.0, 40.0, width=2.0, color=(255, 0, 0, 128))
+        for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
+            restored = pickle.loads(pickle.dumps(edge, protocol=protocol))
+            assert restored.orientation == edge.orientation
+            assert restored.x1 == edge.x1
+
+    def test_table_all_protocols(self, edge_test_doc):
+        tables = find_tables(edge_test_doc.get_page(0), extract_text=True)
+        if not tables:
+            pytest.skip("No tables found")
+        table = tables[0]
+        for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
+            restored = pickle.loads(pickle.dumps(table, protocol=protocol))
+            assert len(restored.cells) == len(table.cells)
+            assert restored.bbox == table.bbox
+
+    def test_tf_settings_all_protocols(self):
+        s = TfSettings(vertical_strategy="lines", horizontal_strategy="text", snap_x_tolerance=5.0)
+        for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
+            restored = pickle.loads(pickle.dumps(s, protocol=protocol))
+            assert restored.vertical_strategy == s.vertical_strategy


### PR DESCRIPTION
All pure-data types (`Table`, `TableCell`, `CellGroup`, `TableCellValue`, `Edge`, `Objects`, `Rect`, `Line`, `Char`, `FillMode`, `TfSettings`, `WordsExtractSettings`) now implement `__reduce__` and can be serialized/deserialized via the Python `pickle` protocol. 

Related to #47 