### PR TITLE
feat: add robust table extraction options

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pdf binary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `text_cell_assignment` to `TfSettings`. The opt-in `"word_overlap"` policy groups glyphs into words before assigning them to the cell with the greatest overlap; the default `"char_center"` preserves existing output.
+- Add `extend_partial_outer_boundaries` to `TfSettings`. When enabled with `close_unclosed_boundaries`, existing incomplete outer edges are extended across the detected table frame. The option defaults to `False` to avoid introducing false-positive cells from incomplete artwork.
+
 ## [0.8.0] - 2026-06-03
 
 ### Added

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -52,6 +52,8 @@ settings = TfSettings(
 | `min_words_horizontal` | `int` | `1` | Minimum words required for horizontal text-based edge detection |
 | `exclude_background_colored_edges` | `bool` | `True` | Whether to exclude edges invisible against their immediate background (see below) |
 | `close_unclosed_boundaries` | `bool` | `True` | Whether to automatically detect and close tables whose outer edges are missing (see below) |
+| `extend_partial_outer_boundaries` | `bool` | `False` | Whether boundary closing also extends existing but incomplete outer edges |
+| `text_cell_assignment` | `str` | `"char_center"` | Assign text by historical character centers or whole-word overlap (`"word_overlap"`) |
 
 **Background-colored edge filtering** (`exclude_background_colored_edges`):
 
@@ -72,6 +74,10 @@ After the raw edges are collected, all h-edges and v-edges that mutually interse
 Once all virtual edges are synthesised, the full intersection-detection and cell-detection pipeline is re-run with the enhanced edge set.
 
 `intersection_x_tolerance` and `intersection_y_tolerance` are used as thresholds when deciding whether an edge truly extends beyond the span. The feature is **skipped entirely** when either strategy is `"text"`, because text-derived edges can extend across table boundaries in ways that would produce false-positive extra columns or rows.
+
+Set `extend_partial_outer_boundaries=True` to make boundary closing extend an outer edge that exists but stops before the table's final row or column. It has no effect when `close_unclosed_boundaries=False` and remains opt-in because incomplete artwork can otherwise create false-positive cells.
+
+Set `text_cell_assignment="word_overlap"` when glyphs from one word cross a cell border. Tablers forms words before cell assignment and places each word in the cell containing the greatest portion of its bounding box. The default `"char_center"` retains historical output.
 
 ### Explicit Edges
 

--- a/python/tablers/typing.py
+++ b/python/tablers/typing.py
@@ -68,10 +68,12 @@ class TfSettingItems(TypedDict, total=False):
     text_read_in_clockwise: bool
     text_split_at_punctuation: Literal["all"] | str | None
     text_expand_ligatures: bool
+    text_cell_assignment: Literal["char_center", "word_overlap"]
     explicit_h_edges: list[Edge] | None
     explicit_v_edges: list[Edge] | None
     exclude_background_colored_edges: bool
     close_unclosed_boundaries: bool
+    extend_partial_outer_boundaries: bool
 
 
 class WordsExtractSettingsItems(TypedDict, total=False):

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -640,6 +640,7 @@ impl TfSettings {
         self.text_settings.expand_ligatures
     }
 
+    /// Returns the policy used to assign extracted text to table cells.
     #[getter]
     fn text_cell_assignment(&self) -> &'static str {
         Self::text_cell_assignment_enum_to_str(self.text_cell_assignment)
@@ -665,6 +666,7 @@ impl TfSettings {
         self.close_unclosed_boundaries
     }
 
+    /// Returns whether boundary closing extends incomplete existing outer edges.
     #[getter]
     fn extend_partial_outer_boundaries(&self) -> bool {
         self.extend_partial_outer_boundaries
@@ -804,6 +806,11 @@ impl TfSettings {
         self.text_settings.expand_ligatures = value;
     }
 
+    /// Sets the policy used to assign extracted text to table cells.
+    ///
+    /// # Errors
+    ///
+    /// Returns `PyValueError` for unsupported policy names.
     #[setter]
     fn set_text_cell_assignment(&mut self, value: &str) -> PyResult<()> {
         self.text_cell_assignment = Self::text_cell_assignment_str_to_enum(value)?;
@@ -830,6 +837,7 @@ impl TfSettings {
         self.close_unclosed_boundaries = value;
     }
 
+    /// Sets whether boundary closing extends incomplete existing outer edges.
     #[setter]
     fn set_extend_partial_outer_boundaries(&mut self, value: bool) {
         self.extend_partial_outer_boundaries = value;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -325,6 +325,19 @@ impl TfSettings {
         }
     }
 
+    /// Converts a Python-facing text-cell assignment name to its enum value.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - The assignment policy name.
+    ///
+    /// # Returns
+    ///
+    /// The matching text-cell assignment policy.
+    ///
+    /// # Errors
+    ///
+    /// Returns `PyValueError` when `value` is not `"char_center"` or `"word_overlap"`.
     fn text_cell_assignment_str_to_enum(value: &str) -> PyResult<TextCellAssignment> {
         match value {
             "char_center" => Ok(TextCellAssignment::CharCenter),
@@ -335,6 +348,15 @@ impl TfSettings {
         }
     }
 
+    /// Converts a text-cell assignment enum value to its Python-facing name.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - The assignment policy enum value.
+    ///
+    /// # Returns
+    ///
+    /// The stable string name of the assignment policy.
     fn text_cell_assignment_enum_to_str(value: TextCellAssignment) -> &'static str {
         match value {
             TextCellAssignment::CharCenter => "char_center",

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -150,6 +150,15 @@ impl BitAnd<StrategyType> for StrategyType {
     }
 }
 
+/// Policy used to assign extracted text to detected table cells.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TextCellAssignment {
+    /// Assign each character independently using its bounding-box center.
+    CharCenter,
+    /// Form words first and assign each whole word to the cell with greatest overlap.
+    WordOverlap,
+}
+
 /// Settings for table finding operations.
 ///
 /// Controls how edges are detected, snapped, joined, and how intersections
@@ -189,6 +198,8 @@ pub struct TfSettings {
     pub min_columns: Option<usize>,
     /// Settings for text/word extraction.
     pub text_settings: WordsExtractSettings,
+    /// Policy used to assign extracted text to table cells.
+    pub text_cell_assignment: TextCellAssignment,
     /// Explicit horizontal edges to include in table detection.
     pub explicit_h_edges: Option<Vec<Edge>>,
     /// Explicit vertical edges to include in table detection.
@@ -222,6 +233,9 @@ pub struct TfSettings {
     /// for deciding whether an edge truly extends beyond the component span.
     /// The feature is skipped entirely when either strategy is `Text`.
     pub close_unclosed_boundaries: bool,
+    /// Whether partial existing outer edges should be extended across the complete frame.
+    /// Has no effect when `close_unclosed_boundaries` is disabled.
+    pub extend_partial_outer_boundaries: bool,
 }
 impl Default for TfSettings {
     /// Creates a TfSettings instance with default values.
@@ -243,10 +257,12 @@ impl Default for TfSettings {
             min_rows: None,
             min_columns: None,
             text_settings: WordsExtractSettings::default(),
+            text_cell_assignment: TextCellAssignment::CharCenter,
             explicit_h_edges: None,
             explicit_v_edges: None,
             exclude_background_colored_edges: true,
             close_unclosed_boundaries: true,
+            extend_partial_outer_boundaries: false,
         }
     }
 }
@@ -306,6 +322,23 @@ impl TfSettings {
             StrategyType::LinesStrict => "lines_strict",
             StrategyType::Text => "text",
             StrategyType::Explicit => "explicit",
+        }
+    }
+
+    fn text_cell_assignment_str_to_enum(value: &str) -> PyResult<TextCellAssignment> {
+        match value {
+            "char_center" => Ok(TextCellAssignment::CharCenter),
+            "word_overlap" => Ok(TextCellAssignment::WordOverlap),
+            _ => Err(PyValueError::new_err(format!(
+                "Invalid text_cell_assignment: {value}. Expected 'char_center' or 'word_overlap'."
+            ))),
+        }
+    }
+
+    fn text_cell_assignment_enum_to_str(value: TextCellAssignment) -> &'static str {
+        match value {
+            TextCellAssignment::CharCenter => "char_center",
+            TextCellAssignment::WordOverlap => "word_overlap",
         }
     }
 }
@@ -424,6 +457,10 @@ impl TfSettings {
                     "text_expand_ligatures" => {
                         settings.text_settings.expand_ligatures = value.extract::<bool>().unwrap()
                     }
+                    "text_cell_assignment" => {
+                        settings.text_cell_assignment =
+                            Self::text_cell_assignment_str_to_enum(value.extract::<&str>()?)?
+                    }
                     "explicit_h_edges" => {
                         settings.explicit_h_edges = value.extract::<Option<Vec<Edge>>>().unwrap()
                     }
@@ -435,6 +472,9 @@ impl TfSettings {
                     }
                     "close_unclosed_boundaries" => {
                         settings.close_unclosed_boundaries = value.extract::<bool>().unwrap()
+                    }
+                    "extend_partial_outer_boundaries" => {
+                        settings.extend_partial_outer_boundaries = value.extract::<bool>().unwrap()
                     }
                     "exclude_white_edges" => {
                         let py = value.py();
@@ -579,6 +619,11 @@ impl TfSettings {
     }
 
     #[getter]
+    fn text_cell_assignment(&self) -> &'static str {
+        Self::text_cell_assignment_enum_to_str(self.text_cell_assignment)
+    }
+
+    #[getter]
     fn explicit_h_edges(&self) -> Option<Vec<Edge>> {
         self.explicit_h_edges.clone()
     }
@@ -596,6 +641,11 @@ impl TfSettings {
     #[getter]
     fn close_unclosed_boundaries(&self) -> bool {
         self.close_unclosed_boundaries
+    }
+
+    #[getter]
+    fn extend_partial_outer_boundaries(&self) -> bool {
+        self.extend_partial_outer_boundaries
     }
 
     // Setters
@@ -733,6 +783,12 @@ impl TfSettings {
     }
 
     #[setter]
+    fn set_text_cell_assignment(&mut self, value: &str) -> PyResult<()> {
+        self.text_cell_assignment = Self::text_cell_assignment_str_to_enum(value)?;
+        Ok(())
+    }
+
+    #[setter]
     fn set_explicit_h_edges(&mut self, value: Option<Vec<Edge>>) {
         self.explicit_h_edges = value;
     }
@@ -752,6 +808,11 @@ impl TfSettings {
         self.close_unclosed_boundaries = value;
     }
 
+    #[setter]
+    fn set_extend_partial_outer_boundaries(&mut self, value: bool) {
+        self.extend_partial_outer_boundaries = value;
+    }
+
     // Dataclass-like methods
     fn __repr__(&self) -> String {
         format!(
@@ -765,10 +826,10 @@ impl TfSettings {
              text_need_strip={}, text_x_tolerance={}, text_y_tolerance={}, \
              text_keep_blank_chars={}, text_use_text_flow={}, \
              text_read_in_clockwise={}, text_split_at_punctuation={:?}, \
-             text_expand_ligatures={}, \
+             text_expand_ligatures={}, text_cell_assignment='{}', \
              explicit_h_edges={}, explicit_v_edges={}, \
              exclude_background_colored_edges={}, \
-             close_unclosed_boundaries={})",
+             close_unclosed_boundaries={}, extend_partial_outer_boundaries={})",
             Self::strategy_enum_to_str(self.vertical_strategy),
             Self::strategy_enum_to_str(self.horizontal_strategy),
             self.snap_x_tolerance,
@@ -792,6 +853,7 @@ impl TfSettings {
             self.text_settings.text_read_in_clockwise,
             self.text_split_at_punctuation(),
             self.text_settings.expand_ligatures,
+            Self::text_cell_assignment_enum_to_str(self.text_cell_assignment),
             self.explicit_h_edges
                 .as_ref()
                 .map_or("None".to_string(), |v| format!("[{} edges]", v.len())),
@@ -800,6 +862,7 @@ impl TfSettings {
                 .map_or("None".to_string(), |v| format!("[{} edges]", v.len())),
             self.exclude_background_colored_edges,
             self.close_unclosed_boundaries,
+            self.extend_partial_outer_boundaries,
         )
     }
 
@@ -828,12 +891,14 @@ impl TfSettings {
                 && self.text_settings.text_read_in_clockwise
                     == other.text_settings.text_read_in_clockwise
                 && self.text_settings.expand_ligatures == other.text_settings.expand_ligatures
+                && self.text_cell_assignment == other.text_cell_assignment
                 && self.explicit_h_edges.as_ref().map(|v| v.len())
                     == other.explicit_h_edges.as_ref().map(|v| v.len())
                 && self.explicit_v_edges.as_ref().map(|v| v.len())
                     == other.explicit_v_edges.as_ref().map(|v| v.len())
                 && self.exclude_background_colored_edges == other.exclude_background_colored_edges
                 && self.close_unclosed_boundaries == other.close_unclosed_boundaries
+                && self.extend_partial_outer_boundaries == other.extend_partial_outer_boundaries
         } else {
             false
         }
@@ -877,6 +942,8 @@ impl TfSettings {
             self.explicit_v_edges.clone(),
             self.exclude_background_colored_edges,
             self.close_unclosed_boundaries,
+            Self::text_cell_assignment_enum_to_str(self.text_cell_assignment).to_string(),
+            self.extend_partial_outer_boundaries,
         );
         Ok((cls.getattr("_from_pickle")?, (part1, part2))
             .into_pyobject(py)?
@@ -912,6 +979,8 @@ impl TfSettings {
             Option<Vec<Edge>>,
             bool,
             bool,
+            String,
+            bool,
         ),
     ) -> PyResult<Self> {
         let (
@@ -937,6 +1006,8 @@ impl TfSettings {
             explicit_v_edges,
             exclude_background_colored_edges,
             close_unclosed_boundaries,
+            text_cell_assignment,
+            extend_partial_outer_boundaries,
         ) = part2;
         let ts = text_settings_state;
         Ok(TfSettings {
@@ -976,10 +1047,12 @@ impl TfSettings {
                 expand_ligatures: ts.6,
                 need_strip: ts.7,
             },
+            text_cell_assignment: Self::text_cell_assignment_str_to_enum(&text_cell_assignment)?,
             explicit_h_edges,
             explicit_v_edges,
             exclude_background_colored_edges,
             close_unclosed_boundaries,
+            extend_partial_outer_boundaries,
         })
     }
 }

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -571,6 +571,7 @@ impl Table {
     /// * `chars` - Optional character array for text extraction.
     /// * `we_settings` - Optional word extraction settings.
     /// * `need_strip` - Whether to strip leading/trailing whitespace from cell text.
+    /// * `text_cell_assignment` - Policy used to assign source text to cells.
     ///
     /// # Returns
     ///
@@ -743,6 +744,15 @@ impl Table {
     }
 
     /// Returns the axis-aligned overlap area between two bounding boxes.
+    ///
+    /// # Arguments
+    ///
+    /// * `left` - The first bounding box.
+    /// * `right` - The second bounding box.
+    ///
+    /// # Returns
+    ///
+    /// The shared area, or zero when the boxes do not overlap.
     #[inline]
     fn bbox_overlap_area(left: &BboxKey, right: &BboxKey) -> OrderedFloat<f32> {
         let width = (left.2.min(right.2) - left.0.max(right.0)).max(OrderedFloat(0.0));
@@ -750,7 +760,20 @@ impl Table {
         width * height
     }
 
-    /// Join words in extraction order while preserving intentional word boundaries.
+    /// Joins words in extraction order while preserving intentional word boundaries.
+    ///
+    /// # Arguments
+    ///
+    /// * `words` - Words in PDF extraction order.
+    /// * `x_tol` - Horizontal gap tolerance used by the historical policy.
+    /// * `y_tol` - Vertical gap tolerance used by the historical policy.
+    /// * `need_strip` - Whether to remove leading and trailing whitespace.
+    /// * `preserve_word_boundaries` - Whether distinct extracted words receive a space unless
+    ///   punctuation or a line-ending hyphen requires attachment.
+    ///
+    /// # Returns
+    ///
+    /// Cell text reconstructed from the supplied words.
     fn words_to_text(
         words: &[Word],
         x_tol: f32,
@@ -788,7 +811,9 @@ impl Table {
         }
     }
 
-    /// Extract text using the historical character-center cell assignment policy.
+    /// Extracts cell text using the historical character-center assignment policy.
+    ///
+    /// Characters are assigned to cells before word formation, preserving existing output.
     fn extract_text_by_char_center(
         &mut self,
         chars: &[Char],
@@ -810,7 +835,11 @@ impl Table {
         }
     }
 
-    /// Extract words first, then assign each whole word to its greatest-overlap cell.
+    /// Extracts words first, then assigns each word to its greatest-overlap cell.
+    ///
+    /// A source token with at least two character centers in multiple cells is split along those
+    /// character groups. This preserves genuinely concatenated neighboring-cell values while a
+    /// one-character border spillover stays attached to the original word.
     fn extract_text_by_word_overlap(
         &mut self,
         chars: &[Char],
@@ -873,6 +902,7 @@ impl Table {
     /// * `chars` - The characters from the page.
     /// * `settings` - Optional word extraction settings.
     /// * `need_strip` - Whether to strip leading/trailing whitespace from cell text.
+    /// * `text_cell_assignment` - Policy used to assign source text to cells.
     pub fn extract_text(
         &mut self,
         chars: &[Char],

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -582,6 +582,7 @@ impl Table {
         chars: Option<&[Char]>,
         we_settings: Option<&WordsExtractSettings>,
         need_strip: bool,
+        text_cell_assignment: TextCellAssignment,
     ) -> Self {
         let bbox = get_table_bbox(cells_bbox);
         let cells = cells_bbox
@@ -599,7 +600,9 @@ impl Table {
         };
         if extract_text {
             match chars {
-                Some(chars) => slf.extract_text(chars, we_settings, need_strip),
+                Some(chars) => {
+                    slf.extract_text(chars, we_settings, need_strip, text_cell_assignment)
+                }
                 None => panic!("No chars provided"),
             };
         };
@@ -739,6 +742,130 @@ impl Table {
         h_mid >= x1 && h_mid < x2 && v_mid >= y1 && v_mid < y2
     }
 
+    /// Returns the axis-aligned overlap area between two bounding boxes.
+    #[inline]
+    fn bbox_overlap_area(left: &BboxKey, right: &BboxKey) -> OrderedFloat<f32> {
+        let width = (left.2.min(right.2) - left.0.max(right.0)).max(OrderedFloat(0.0));
+        let height = (left.3.min(right.3) - left.1.max(right.1)).max(OrderedFloat(0.0));
+        width * height
+    }
+
+    /// Join words in extraction order while preserving intentional word boundaries.
+    fn words_to_text(
+        words: &[Word],
+        x_tol: f32,
+        y_tol: f32,
+        need_strip: bool,
+        preserve_word_boundaries: bool,
+    ) -> String {
+        let mut text = String::new();
+        for (index, word) in words.iter().enumerate() {
+            if index > 0 {
+                let previous = &words[index - 1];
+                let punctuation_attaches = word
+                    .text
+                    .starts_with(|character: char| ",.;:!?%)]}".contains(character));
+                let opening_attaches = previous
+                    .text
+                    .ends_with(|character: char| "([{".contains(character));
+                let line_hyphen_attaches = previous.text.len() > 1 && previous.text.ends_with('-');
+                if (preserve_word_boundaries
+                    && !punctuation_attaches
+                    && !opening_attaches
+                    && !line_hyphen_attaches)
+                    || (!preserve_word_boundaries
+                        && Self::word_gap_requires_space(previous, word, x_tol, y_tol))
+                {
+                    text.push(' ');
+                }
+            }
+            text.push_str(&word.text.replace("\r\n", "\n").replace('\r', "\n"));
+        }
+        if need_strip {
+            text.trim().to_string()
+        } else {
+            text
+        }
+    }
+
+    /// Extract text using the historical character-center cell assignment policy.
+    fn extract_text_by_char_center(
+        &mut self,
+        chars: &[Char],
+        word_extractor: &WordExtractor,
+        x_tol: f32,
+        y_tol: f32,
+        need_strip: bool,
+    ) {
+        for cell in &mut self.cells {
+            let cell_chars: Vec<Char> = chars
+                .iter()
+                .filter(|char| Self::char_in_bbox(char, &cell.bbox))
+                .cloned()
+                .collect();
+            if !cell_chars.is_empty() {
+                let words = word_extractor.extract_words(&cell_chars);
+                cell.text = Self::words_to_text(&words, x_tol, y_tol, need_strip, false);
+            }
+        }
+    }
+
+    /// Extract words first, then assign each whole word to its greatest-overlap cell.
+    fn extract_text_by_word_overlap(
+        &mut self,
+        chars: &[Char],
+        word_extractor: &WordExtractor,
+        x_tol: f32,
+        y_tol: f32,
+        need_strip: bool,
+    ) {
+        let table_chars: Vec<Char> = chars
+            .iter()
+            .filter(|char| Self::char_in_bbox(char, &self.bbox))
+            .cloned()
+            .collect();
+        let mut cell_words = vec![Vec::new(); self.cells.len()];
+        for (word, word_chars) in word_extractor.iter_extract_tuples(&table_chars) {
+            let mut chars_by_cell = vec![Vec::new(); self.cells.len()];
+            for character in &word_chars {
+                if let Some(cell_index) = self
+                    .cells
+                    .iter()
+                    .position(|cell| Self::char_in_bbox(character, &cell.bbox))
+                {
+                    chars_by_cell[cell_index].push(character.clone());
+                }
+            }
+            let substantial_cell_count = chars_by_cell
+                .iter()
+                .filter(|cell_chars| cell_chars.len() >= 2)
+                .count();
+            if substantial_cell_count >= 2 {
+                for (cell_index, cell_chars) in chars_by_cell.into_iter().enumerate() {
+                    if !cell_chars.is_empty() {
+                        cell_words[cell_index].push(word_extractor.merge_chars(&cell_chars));
+                    }
+                }
+                continue;
+            }
+            let mut best: Option<(usize, OrderedFloat<f32>)> = None;
+            for (cell_index, cell) in self.cells.iter().enumerate() {
+                let overlap = Self::bbox_overlap_area(&word.bbox, &cell.bbox);
+                if overlap > OrderedFloat(0.0)
+                    && best.is_none_or(|(_, best_overlap)| overlap > best_overlap)
+                {
+                    best = Some((cell_index, overlap));
+                }
+            }
+            if let Some((cell_index, _)) = best {
+                cell_words[cell_index].push(word);
+            }
+        }
+        for (cell, words) in self.cells.iter_mut().zip(cell_words) {
+            cell.text = Self::words_to_text(&words, x_tol, y_tol, need_strip, true);
+        }
+    }
+
     /// Extracts text content for all cells in the table.
     ///
     /// # Arguments
@@ -751,40 +878,24 @@ impl Table {
         chars: &[Char],
         settings: Option<&WordsExtractSettings>,
         need_strip: bool,
+        text_cell_assignment: TextCellAssignment,
     ) {
         let default_settings = WordsExtractSettings::default();
         let base_settings = settings.unwrap_or(&default_settings);
         let word_settings = WordsExtractSettings {
-            keep_blank_chars: true, // keep_blank_chars should be true anyway
+            keep_blank_chars: text_cell_assignment == TextCellAssignment::CharCenter,
             ..base_settings.clone()
         };
         let word_extractor = WordExtractor::new(&word_settings);
         let x_tol = word_settings.x_tolerance.into_inner();
         let y_tol = word_settings.y_tolerance.into_inner();
 
-        for cell in &mut self.cells {
-            let cell_chars: Vec<Char> = chars
-                .iter()
-                .filter(|char| Self::char_in_bbox(char, &cell.bbox))
-                .cloned()
-                .collect();
-
-            if !cell_chars.is_empty() {
-                let words = word_extractor.extract_words(&cell_chars);
-                let mut text = String::new();
-                for (i, w) in words.iter().enumerate() {
-                    if i > 0 {
-                        let prev = &words[i - 1];
-                        if Self::word_gap_requires_space(prev, w, x_tol, y_tol) {
-                            text.push(' ');
-                        }
-                    }
-                    text.push_str(&w.text.replace("\r\n", "\n").replace('\r', "\n"));
-                }
-                if need_strip {
-                    text = text.trim().to_string();
-                }
-                cell.text = text;
+        match text_cell_assignment {
+            TextCellAssignment::CharCenter => {
+                self.extract_text_by_char_center(chars, &word_extractor, x_tol, y_tol, need_strip)
+            }
+            TextCellAssignment::WordOverlap => {
+                self.extract_text_by_word_overlap(chars, &word_extractor, x_tol, y_tol, need_strip)
             }
         }
         self.text_extracted = true;
@@ -2190,6 +2301,7 @@ fn compute_outer_frame_edges(
     v_edges: &[Edge],
     x_tol: OrderedFloat<f32>,
     y_tol: OrderedFloat<f32>,
+    extend_partial_outer_boundaries: bool,
 ) -> Vec<Edge> {
     let n_h = h_edges.len();
     let n_v = v_edges.len();
@@ -2244,17 +2356,53 @@ fn compute_outer_frame_edges(
         let y_v_min = v_idxs.iter().map(|&i| v_edges[i].y1).min().unwrap();
         let y_v_max = v_idxs.iter().map(|&i| v_edges[i].y2).max().unwrap();
 
-        if x_h_min < x_int_min - x_tol {
-            virtual_edges.push(virtual_v_edge(x_h_min, y_v_min, y_v_max));
+        if !extend_partial_outer_boundaries {
+            if x_h_min < x_int_min - x_tol {
+                virtual_edges.push(virtual_v_edge(x_h_min, y_v_min, y_v_max));
+            }
+            if x_h_max > x_int_max + x_tol {
+                virtual_edges.push(virtual_v_edge(x_h_max, y_v_min, y_v_max));
+            }
+            if y_v_min < y_int_min - y_tol {
+                virtual_edges.push(virtual_h_edge(x_h_min, y_v_min, x_h_max));
+            }
+            if y_v_max > y_int_max + y_tol {
+                virtual_edges.push(virtual_h_edge(x_h_min, y_v_max, x_h_max));
+            }
+            continue;
         }
-        if x_h_max > x_int_max + x_tol {
-            virtual_edges.push(virtual_v_edge(x_h_max, y_v_min, y_v_max));
+
+        let left_x = x_h_min.min(x_int_min);
+        let right_x = x_h_max.max(x_int_max);
+        let top_y = y_v_min.min(y_int_min);
+        let bottom_y = y_v_max.max(y_int_max);
+        let vertical_boundary_is_complete = |x: OrderedFloat<f32>| {
+            v_idxs.iter().any(|&index| {
+                let edge = &v_edges[index];
+                (edge.x1 - x).abs() <= x_tol.into_inner()
+                    && edge.y1 <= top_y + y_tol
+                    && edge.y2 >= bottom_y - y_tol
+            })
+        };
+        let horizontal_boundary_is_complete = |y: OrderedFloat<f32>| {
+            h_idxs.iter().any(|&index| {
+                let edge = &h_edges[index];
+                (edge.y1 - y).abs() <= y_tol.into_inner()
+                    && edge.x1 <= left_x + x_tol
+                    && edge.x2 >= right_x - x_tol
+            })
+        };
+        if !vertical_boundary_is_complete(left_x) {
+            virtual_edges.push(virtual_v_edge(left_x, top_y, bottom_y));
         }
-        if y_v_min < y_int_min - y_tol {
-            virtual_edges.push(virtual_h_edge(x_h_min, y_v_min, x_h_max));
+        if !vertical_boundary_is_complete(right_x) {
+            virtual_edges.push(virtual_v_edge(right_x, top_y, bottom_y));
         }
-        if y_v_max > y_int_max + y_tol {
-            virtual_edges.push(virtual_h_edge(x_h_min, y_v_max, x_h_max));
+        if !horizontal_boundary_is_complete(top_y) {
+            virtual_edges.push(virtual_h_edge(left_x, top_y, right_x));
+        }
+        if !horizontal_boundary_is_complete(bottom_y) {
+            virtual_edges.push(virtual_h_edge(left_x, bottom_y, right_x));
         }
     }
 
@@ -2358,7 +2506,13 @@ pub fn find_all_cells_bboxes(
         let h_edges = edges.get(&Orientation::Horizontal).unwrap();
         let v_edges = edges.get(&Orientation::Vertical).unwrap();
 
-        let virtual_edges = compute_outer_frame_edges(h_edges, v_edges, x_tol, y_tol);
+        let virtual_edges = compute_outer_frame_edges(
+            h_edges,
+            v_edges,
+            x_tol,
+            y_tol,
+            tf_settings.extend_partial_outer_boundaries,
+        );
         if !virtual_edges.is_empty() {
             for e in virtual_edges {
                 edges.entry(e.orientation).or_default().push(e);
@@ -2428,6 +2582,9 @@ pub fn find_tables_from_cells(
                 chars,
                 we_settings,
                 need_strip,
+                tf_settings.map_or(TextCellAssignment::CharCenter, |settings| {
+                    settings.text_cell_assignment
+                }),
             )
         })
         .collect()
@@ -2706,6 +2863,101 @@ mod tests {
 
         // Char center is (16.5, 16.5), which is outside the bbox
         assert!(!Table::char_in_bbox(&char, &bbox));
+    }
+
+    fn make_char(text: &str, x1: f32, x2: f32) -> Char {
+        Char {
+            unicode_char: Some(text.to_string()),
+            bbox: (of(x1), of(1.0), of(x2), of(9.0)),
+            rotation_degrees: of(0.0),
+            upright: true,
+        }
+    }
+
+    #[test]
+    fn test_word_overlap_keeps_border_crossing_word_in_one_cell() {
+        let cells = vec![
+            (of(0.0), of(0.0), of(10.0), of(10.0)),
+            (of(10.0), of(0.0), of(20.0), of(10.0)),
+        ];
+        let chars = vec![
+            make_char("P", 3.0, 5.0),
+            make_char("O", 5.0, 7.0),
+            make_char("C", 7.0, 9.0),
+            make_char(")", 9.0, 11.0),
+        ];
+
+        let table = Table::new(
+            0,
+            &cells,
+            true,
+            Some(&chars),
+            None,
+            true,
+            TextCellAssignment::WordOverlap,
+        );
+
+        assert_eq!(table.cells[0].text, "POC)");
+        assert_eq!(table.cells[1].text, "");
+    }
+
+    #[test]
+    fn test_word_overlap_splits_concatenated_neighboring_cell_tokens() {
+        let cells = vec![
+            (of(0.0), of(0.0), of(10.0), of(10.0)),
+            (of(10.0), of(0.0), of(20.0), of(10.0)),
+        ];
+        let chars = "ABCDWXYZ"
+            .chars()
+            .enumerate()
+            .map(|(index, character)| {
+                make_char(
+                    &character.to_string(),
+                    6.0 + index as f32,
+                    7.0 + index as f32,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let table = Table::new(
+            0,
+            &cells,
+            true,
+            Some(&chars),
+            None,
+            true,
+            TextCellAssignment::WordOverlap,
+        );
+
+        assert_eq!(table.cells[0].text, "ABCD");
+        assert_eq!(table.cells[1].text, "WXYZ");
+    }
+
+    #[test]
+    fn test_char_center_preserves_historical_border_split() {
+        let cells = vec![
+            (of(0.0), of(0.0), of(10.0), of(10.0)),
+            (of(10.0), of(0.0), of(20.0), of(10.0)),
+        ];
+        let chars = vec![
+            make_char("P", 5.0, 7.0),
+            make_char("O", 7.0, 9.0),
+            make_char("C", 9.0, 11.0),
+            make_char(")", 11.0, 13.0),
+        ];
+
+        let table = Table::new(
+            0,
+            &cells,
+            true,
+            Some(&chars),
+            None,
+            true,
+            TextCellAssignment::CharCenter,
+        );
+
+        assert_eq!(table.cells[0].text, "PO");
+        assert_eq!(table.cells[1].text, "C)");
     }
 
     fn make_word(x1: f32, y1: f32, x2: f32, y2: f32, rotation: f32) -> Word {
@@ -4835,7 +5087,7 @@ mod tests {
     fn test_outer_frame_no_intersection_returns_empty() {
         let h = vec![make_h_edge(0.0, 10.0, 40.0)];
         let v = vec![make_v_edge(60.0, 0.0, 50.0)];
-        let result = compute_outer_frame_edges(&h, &v, of(2.0), of(2.0));
+        let result = compute_outer_frame_edges(&h, &v, of(2.0), of(2.0), false);
         assert!(result.is_empty());
     }
 
@@ -4853,8 +5105,32 @@ mod tests {
             make_v_edge(50.0, 0.0, 100.0),
             make_v_edge(100.0, 0.0, 100.0),
         ];
-        let result = compute_outer_frame_edges(&h, &v, of(2.0), of(2.0));
+        let result = compute_outer_frame_edges(&h, &v, of(2.0), of(2.0), false);
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_outer_frame_extends_partial_existing_boundary_when_enabled() {
+        let h = vec![
+            make_h_edge(0.0, 0.0, 100.0),
+            make_h_edge(0.0, 50.0, 100.0),
+            make_h_edge(0.0, 100.0, 100.0),
+        ];
+        let v = vec![
+            make_v_edge(0.0, 0.0, 100.0),
+            make_v_edge(50.0, 0.0, 100.0),
+            make_v_edge(100.0, 0.0, 50.0),
+        ];
+
+        let disabled = compute_outer_frame_edges(&h, &v, of(2.0), of(2.0), false);
+        let enabled = compute_outer_frame_edges(&h, &v, of(2.0), of(2.0), true);
+
+        assert!(disabled.is_empty());
+        assert_eq!(enabled.len(), 1);
+        assert_eq!(enabled[0].orientation, Orientation::Vertical);
+        assert_eq!(enabled[0].x1, of(100.0));
+        assert_eq!(enabled[0].y1, of(0.0));
+        assert_eq!(enabled[0].y2, of(100.0));
     }
 
     #[test]
@@ -4862,7 +5138,7 @@ mod tests {
         // h-edges extend left beyond the single v-edge → virtual v-edge on left.
         let h = vec![make_h_edge(0.0, 0.0, 50.0), make_h_edge(0.0, 50.0, 50.0)];
         let v = vec![make_v_edge(50.0, 0.0, 50.0)];
-        let result = compute_outer_frame_edges(&h, &v, of(2.0), of(2.0));
+        let result = compute_outer_frame_edges(&h, &v, of(2.0), of(2.0), false);
         let v_edges: Vec<_> = result
             .iter()
             .filter(|e| e.orientation == Orientation::Vertical)
@@ -4879,7 +5155,7 @@ mod tests {
             make_h_edge(50.0, 50.0, 100.0),
         ];
         let v = vec![make_v_edge(50.0, 0.0, 50.0)];
-        let result = compute_outer_frame_edges(&h, &v, of(2.0), of(2.0));
+        let result = compute_outer_frame_edges(&h, &v, of(2.0), of(2.0), false);
         let v_edges: Vec<_> = result
             .iter()
             .filter(|e| e.orientation == Orientation::Vertical)
@@ -4893,7 +5169,7 @@ mod tests {
         // v-edges extend above and below the single h-edge → two virtual h-edges.
         let h = vec![make_h_edge(0.0, 50.0, 100.0)];
         let v = vec![make_v_edge(0.0, 0.0, 100.0), make_v_edge(100.0, 0.0, 100.0)];
-        let result = compute_outer_frame_edges(&h, &v, of(2.0), of(2.0));
+        let result = compute_outer_frame_edges(&h, &v, of(2.0), of(2.0), false);
         let h_edges: Vec<_> = result
             .iter()
             .filter(|e| e.orientation == Orientation::Horizontal)
@@ -4914,7 +5190,7 @@ mod tests {
             make_h_edge(200.0, 50.0, 250.0),
         ];
         let v = vec![make_v_edge(50.0, 0.0, 50.0), make_v_edge(250.0, 0.0, 50.0)];
-        let result = compute_outer_frame_edges(&h, &v, of(2.0), of(2.0));
+        let result = compute_outer_frame_edges(&h, &v, of(2.0), of(2.0), false);
         let v_virtual: Vec<_> = result
             .iter()
             .filter(|e| e.orientation == Orientation::Vertical)

--- a/tests/data/partial-outer-boundary.pdf
+++ b/tests/data/partial-outer-boundary.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+%“Œ‹ ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 432 720 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20000101000000+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20000101000000+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /FlateDecode ] /Length 160
+>>
+stream
+xœu1Â0F÷şŠoTA½KÓk»trz¸‹ÔAšôï‹51Uìr/Ç…A ğ0O¨ë-ƒô¶+İa£	ã‘tÈ2²pH…†­Eíq.ç±ØÂc±ÅÈ"şıM‹Ç¯-òü®LY©ÿ£$P‡Ù~ÉÄsèºø±ŒÚáØŞ›ÿZIÈRùÄÌt,huÓİúëÈCòÃL®endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000061 00000 n 
+0000000092 00000 n 
+0000000199 00000 n 
+0000000392 00000 n 
+0000000460 00000 n 
+0000000721 00000 n 
+0000000780 00000 n 
+trailer
+<<
+/ID 
+[<1c178198fbdfa51b25995d89d4102043><1c178198fbdfa51b25995d89d4102043>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1015
+%%EOF

--- a/tests/data/word-overlap-cell-assignment.pdf
+++ b/tests/data/word-overlap-cell-assignment.pdf
@@ -1,0 +1,68 @@
+%PDF-1.3
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 432 720 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20000101000000+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20000101000000+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /FlateDecode ] /Length 161
+>>
+stream
+xœuË‚@E÷|Å]ªm‡¡à–W.Ô/0¢FCâïÆ!øÜ47§'}0öõà€\±Ú0Ø@k°]Zè…FŒ{tEj…C,äS‹*àTFœÊ„Åfi²ýÐRÃð&>nzŸòïÌ\Ã/C„2¨ÃlWUµ/‹9ô]|˜kB‹ó®ï;‡öX÷¿]c¿ä[s:¿ÚˆÏJÎendstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000061 00000 n 
+0000000092 00000 n 
+0000000199 00000 n 
+0000000392 00000 n 
+0000000460 00000 n 
+0000000721 00000 n 
+0000000780 00000 n 
+trailer
+<<
+/ID 
+[<1c178198fbdfa51b25995d89d4102043><1c178198fbdfa51b25995d89d4102043>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1016
+%%EOF

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -247,6 +247,40 @@ def tables_unclosed_boundaries_doc(
 
 
 @pytest.fixture
+def partial_outer_boundary_pdf_path() -> Path:
+    """Return the partial-outer-boundary.pdf regression fixture path."""
+    return TEST_DATA_DIR / "partial-outer-boundary.pdf"
+
+
+@pytest.fixture
+def partial_outer_boundary_doc(
+    partial_outer_boundary_pdf_path: Path,
+) -> Generator[Document, None, None]:
+    """Open the partial outer-boundary regression fixture."""
+    doc = Document(path=partial_outer_boundary_pdf_path)
+    yield doc
+    if not doc.is_closed():
+        doc.close()
+
+
+@pytest.fixture
+def word_overlap_cell_assignment_pdf_path() -> Path:
+    """Return the word-overlap-cell-assignment.pdf regression fixture path."""
+    return TEST_DATA_DIR / "word-overlap-cell-assignment.pdf"
+
+
+@pytest.fixture
+def word_overlap_cell_assignment_doc(
+    word_overlap_cell_assignment_pdf_path: Path,
+) -> Generator[Document, None, None]:
+    """Open the word-overlap cell-assignment regression fixture."""
+    doc = Document(path=word_overlap_cell_assignment_pdf_path)
+    yield doc
+    if not doc.is_closed():
+        doc.close()
+
+
+@pytest.fixture
 def edge_test_pdf_bytes(edge_test_pdf_path: Path) -> bytes:
     """Return the content of edge-test.pdf as bytes."""
     return edge_test_pdf_path.read_bytes()

--- a/tests/python/test_pickle.py
+++ b/tests/python/test_pickle.py
@@ -231,6 +231,8 @@ class TestTfSettingsPickle:
             min_rows=2,
             min_columns=3,
             text_split_at_punctuation=".,;",
+            text_cell_assignment="word_overlap",
+            extend_partial_outer_boundaries=True,
         )
         restored = pickle.loads(pickle.dumps(s))
         assert restored.vertical_strategy == "lines"
@@ -239,6 +241,8 @@ class TestTfSettingsPickle:
         assert restored.min_rows == 2
         assert restored.min_columns == 3
         assert restored.text_split_at_punctuation == ".,;"
+        assert restored.text_cell_assignment == "word_overlap"
+        assert restored.extend_partial_outer_boundaries is True
 
     def test_pickle_with_explicit_edges(self):
         h_edges = [Edge("h", 0, 0, 100, 0), Edge("h", 0, 50, 100, 50)]

--- a/tests/python/test_settings.py
+++ b/tests/python/test_settings.py
@@ -229,6 +229,24 @@ class TestTfSettings:
         assert settings.snap_y_tolerance == 5.0
         assert settings.edge_min_length == 15.0
 
+    def test_robust_table_options_are_opt_in(self) -> None:
+        """Robust boundary and text assignment policies preserve legacy defaults."""
+        defaults = TfSettings()
+        assert defaults.extend_partial_outer_boundaries is False
+        assert defaults.text_cell_assignment == "char_center"
+
+        robust = TfSettings(
+            extend_partial_outer_boundaries=True,
+            text_cell_assignment="word_overlap",
+        )
+        assert robust.extend_partial_outer_boundaries is True
+        assert robust.text_cell_assignment == "word_overlap"
+
+    def test_invalid_text_cell_assignment_raises(self) -> None:
+        """TfSettings rejects unknown text-to-cell assignment policies."""
+        with pytest.raises(ValueError, match="Invalid text_cell_assignment"):
+            TfSettings(text_cell_assignment="nearest")
+
 
 class TestNonNegativeValidation:
     """Tests for non-negative value validation in settings."""

--- a/tests/python/test_tables.py
+++ b/tests/python/test_tables.py
@@ -1152,6 +1152,79 @@ class TestTablesUnclosedBoundariesPdf:
         )
 
 
+class TestPartialOuterBoundaryPdf:
+    """Integration tests for extending an existing but incomplete outer boundary."""
+
+    def test_default_preserves_incomplete_boundary(
+        self, partial_outer_boundary_doc: Document
+    ) -> None:
+        """Default boundary closing must preserve the existing three-cell result."""
+        page = partial_outer_boundary_doc.get_page(0)
+        tables = find_tables(page, extract_text=True)
+
+        assert len(tables) == 1
+        assert len(tables[0].cells) == 3
+        assert "Sensor" not in {cell.text for cell in tables[0].cells}
+
+    def test_partial_boundary_extension_recovers_missing_cell(
+        self, partial_outer_boundary_doc: Document
+    ) -> None:
+        """The opt-in extension should close the partial edge and recover its cell."""
+        page = partial_outer_boundary_doc.get_page(0)
+        settings = TfSettings(extend_partial_outer_boundaries=True)
+        tables = find_tables(page, extract_text=True, tf_settings=settings)
+
+        assert len(tables) == 1
+        assert len(tables[0].cells) == 4
+        assert "Sensor" in {cell.text for cell in tables[0].cells}
+
+    def test_parent_boundary_setting_disables_partial_extension(
+        self, partial_outer_boundary_doc: Document
+    ) -> None:
+        """The subordinate option must not act when boundary closing is disabled."""
+        page = partial_outer_boundary_doc.get_page(0)
+        settings = TfSettings(
+            close_unclosed_boundaries=False,
+            extend_partial_outer_boundaries=True,
+        )
+        tables = find_tables(page, extract_text=True, tf_settings=settings)
+
+        assert len(tables) == 1
+        assert len(tables[0].cells) == 3
+        assert "Sensor" not in {cell.text for cell in tables[0].cells}
+
+
+class TestWordOverlapCellAssignmentPdf:
+    """Integration tests for assigning a border-crossing word to one cell."""
+
+    def test_default_preserves_character_center_assignment(
+        self, word_overlap_cell_assignment_doc: Document
+    ) -> None:
+        """The default policy should preserve the historical split-word output."""
+        page = word_overlap_cell_assignment_doc.get_page(0)
+        tables = find_tables(page, extract_text=True)
+
+        assert len(tables) == 1
+        assert [[cell.text for cell in row] for row in tables[0].to_list()] == [
+            ["P", "RESSURE"],
+            ["Bottom left", "Bottom right"],
+        ]
+
+    def test_word_overlap_keeps_border_spillover_with_word(
+        self, word_overlap_cell_assignment_doc: Document
+    ) -> None:
+        """Word-overlap assignment should place the complete word in its best-overlap cell."""
+        page = word_overlap_cell_assignment_doc.get_page(0)
+        settings = TfSettings(text_cell_assignment="word_overlap")
+        tables = find_tables(page, extract_text=True, tf_settings=settings)
+
+        assert len(tables) == 1
+        assert [[cell.text for cell in row] for row in tables[0].to_list()] == [
+            ["", "PRESSURE"],
+            ["Bottom left", "Bottom right"],
+        ]
+
+
 class TestNarrowUnclosedPolylineAsEdgePdf:
     """Tests for #30-narrow-unclosed-polyline-as-edge.pdf.
 


### PR DESCRIPTION
## Summary

- add an opt-in `word_overlap` policy that forms words before assigning text to cells
- add opt-in extension of partially present outer boundaries under the existing boundary-closing feature
- preserve the current character-center and boundary behavior by default

## Motivation

Table text is currently assigned to cells one character at a time using each glyph's center. A word crossing a cell boundary can therefore be split between adjacent cells even when most of the word belongs to one cell.

`close_unclosed_boundaries` can synthesize an entirely missing outer edge, but an edge at the correct coordinate that covers only part of the table prevents that synthesis. Extending partial edges unconditionally can create false-positive cells from incomplete artwork, so the stronger behavior is exposed as a subordinate opt-in setting.

## Changes

### Text assignment

`TfSettings(text_cell_assignment="word_overlap")`:

- groups source glyphs into words before cell assignment
- assigns a word to the cell with the greatest bounding-box overlap
- keeps one-character border spillovers attached to their word
- splits a concatenated source token only when its glyph centers demonstrate that it spans neighboring cells
- preserves spacing, punctuation, line-wrap hyphens, and rotated-text ordering

The default remains `text_cell_assignment="char_center"`.

### Partial boundaries

`TfSettings(extend_partial_outer_boundaries=True)` makes the existing `close_unclosed_boundaries` pass extend an incomplete outer edge across the connected table frame. The option has no effect when `close_unclosed_boundaries=False`.

The default is `False`. This is intentional: enabling the stronger algorithm globally changes an existing white-edge fixture from 245 to 315 cells because incomplete artwork can be interpreted as table structure.

Both settings participate in the Python API, generated typing metadata, representation, equality, and pickle round trips. New Rust items and changed public parameters include newcomer-oriented rustdoc.

## Regression coverage

- Rust unit tests cover legacy character-center behavior, one-character word spillover, concatenated neighboring-cell tokens, and opt-in partial-edge extension.
- `partial-outer-boundary.pdf` exercises the public Python API with default behavior, enabled partial extension, and `close_unclosed_boundaries=False` overriding its subordinate option.
- `word-overlap-cell-assignment.pdf` verifies historical split-word output by default and complete-word assignment with `word_overlap`.
- Python settings and pickle tests cover defaults, validation, and round trips for both options.

## Validation

- `pdm run stub`
- `prek run --all-files`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`
- `pdm run test`
  - 194 Rust tests passed
  - 368 Python tests passed, 1 skipped

The combined opt-in settings were also evaluated against a private application corpus of 35 unique table-bearing PDFs. They recovered 11 identity cells missed by the current defaults and matched all 1,978 PyMuPDF identity rows. Manual review favored Tablers for the two remaining non-whitespace text differences. In that one-run corpus benchmark, Tablers completed summed extraction in 1.95 seconds versus 49.21 seconds for PyMuPDF.

## Compatibility

Existing callers retain the current behavior because both new settings default to their historical policies. No existing setting or return type changes.
