### PR TITLE
fix: support documents on worker threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow separate threads to create and use their own `Document` instances by creating each PyO3 runtime handle on the calling thread and explicitly enabling pdfium-render's mutex-backed `thread_safe` feature. Process-global Pdfium initializes without retaining a thread-bound handle, and the legacy `PDFIUM_RT` export resolves on its caller's thread. Documents and pages remain bound to their creating thread; Pdfium calls are serialized within a process.
+
 ## [0.8.0] - 2026-06-03
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,6 @@ itertools = "0.14.0"
 once_cell = "1.21.3"
 ordered-float = "5.1.0"
 # pdfium-render issue #236 to deal with pdf with page_count >= 65535
-pdfium-render = { git = "https://github.com/ajrcarey/pdfium-render", rev = "0dbad90b" }
+pdfium-render = { git = "https://github.com/ajrcarey/pdfium-render", rev = "0dbad90b", features = ["thread_safe"] }
 pyo3 = { version = "0.28", features = ["abi3-py310"] }
 thiserror = "2.0"

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For more details, please refer to the [tablers-benchmark](https://github.com/mon
 ## Note
 
 - This solution is primarily designed for text-based PDFs and does not support scanned PDFs.
-- **Thread Safety**: `tablers` is **not thread-safe**. The library creates a global PDFium runtime at import time, which is bound to the importing thread. All `Document` operations must be performed on the same thread that imported `tablers`. Using `Document` from a different thread will raise a `PanicException`. For multi-threaded environments, import and use `tablers` within the same worker thread. Use `multiprocessing` for parallel processing instead. See [Thread Safety](docs/usage/advanced.md#thread-safety) for details and code examples.
+- **Thread Safety**: Separate `Document` instances can be created and used concurrently on different threads. A document and its pages must remain on their creating thread. Pdfium calls are mutex-serialized, so use `multiprocessing` when true parallel extraction is required. See [Thread Safety](docs/usage/advanced.md#thread-safety) for details.
 
 ## Installation
 

--- a/docs/usage/advanced.md
+++ b/docs/usage/advanced.md
@@ -428,43 +428,44 @@ Once all virtual edges are synthesised, the full intersection-detection and cell
 
 ## Thread Safety
 
-**`tablers` is not thread-safe.** The library creates a global `PDFIUM_RT` runtime at import time, which is bound to the importing thread. All `Document` operations must be performed on the same thread that imported `tablers`. Using `Document` from a different thread will raise a `PanicException`:
+Separate threads may safely create and use their own `Document` instances. A document and every `Page` obtained from it remain bound to the thread that created the document; do not pass those objects between threads. Pure-data extraction results such as `Table`, `TableCell`, and `Edge` may be passed between threads or processes.
 
-```text
-PanicException: assertion `left == right` failed: tablers::PdfiumRuntime is unsendable, but sent to another thread
-```
+### How Thread Safety Works
 
-### Why Not Thread-Safe?
+tablers is built on [pdfium-render](https://github.com/ajrcarey/pdfium-render), which in turn wraps Pdfium. Pdfium itself makes no thread-safety guarantee. tablers therefore explicitly enables pdfium-render's `thread_safe` feature, which protects the process-global Pdfium bindings with a mutex. Each `Document` creates a cheap PyO3 `PdfiumRuntime` handle on its calling thread while reusing the process-global native Pdfium instance. This avoids moving PyO3 objects marked `unsendable` between threads.
 
-tablers is built on [pdfium-render](https://github.com/ajrcarey/pdfium-render), which in turn wraps Pdfium. Pdfium itself is [explicitly not thread-safe](https://github.com/ajrcarey/pdfium-render#multi-threading) — the Pdfium authors recommend parallel processing over multi-threading. Although pdfium-render offers a `thread_safe` compile-time feature that locks access to Pdfium behind a mutex, enabling it would introduce performance overhead (mutex acquisition even in single-threaded use) and requires an explicit compile-time feature declaration. For these reasons, tablers does not enable thread safety and recommends `multiprocessing` for parallel workloads.
+The mutex makes multi-threaded access safe, not parallel: only one thread executes a Pdfium call at a time. Table detection work outside Pdfium may still run normally, but workloads seeking parallel PDF processing should use separate processes.
+
+The legacy `PDFIUM_RT` export resolves a fresh handle on the thread that accesses it. A handle captured with `from tablers import PDFIUM_RT` is still bound to that thread and must not be passed elsewhere; use `Document()` or resolve another handle on the destination worker instead.
 
 ### Multi-Threaded Environments
 
-In multi-threaded environments (e.g., FastAPI, Celery), make sure to import and use `tablers` within the same worker thread:
+In multi-threaded environments (for example FastAPI or application worker threads), create and fully consume each document within one worker. Importing `tablers` on the main thread is safe because `Document()` resolves a runtime handle local to the calling thread:
 
 ```python
-# ❌ Wrong: import on main thread, use on worker thread
 import threading
 from tablers import Document
 
 def worker():
-    with Document("example.pdf") as doc:  # PanicException!
-        pass
+    with Document("example.pdf") as doc:
+        page = doc.get_page(0)
+        print(page.width)
 
 threading.Thread(target=worker).start()
 ```
 
+Do not create a document on one thread and use it from another:
+
 ```python
-# ✅ Correct: import and use on the same worker thread
 import threading
+from tablers import Document
 
-def worker():
-    from tablers import Document, find_tables  # Import inside the worker thread
-    with Document("example.pdf") as doc:
-        for page in doc.pages():
-            tables = find_tables(page, extract_text=True)
+doc = Document("example.pdf")
 
-threading.Thread(target=worker).start()
+def wrong_worker():
+    print(doc.page_count)  # Document belongs to the main thread.
+
+threading.Thread(target=wrong_worker).start()
 ```
 
 ### Multiprocessing

--- a/python/tablers/__init__.py
+++ b/python/tablers/__init__.py
@@ -24,18 +24,11 @@ Notes
 The library automatically loads the appropriate Pdfium library
 based on the operating system (Windows, Linux, or macOS).
 
-**Thread Safety**: This library is NOT thread-safe. A global
-``PDFIUM_RT`` is created at import time and is bound to the
-importing thread. All ``Document`` operations must run on that
-same thread. Using ``Document`` from a different thread will
-raise a ``PanicException``. In multi-threaded environments,
-import and use this library within the same worker thread, or
-use ``multiprocessing`` instead of ``threading``.
-
-Although `pdfium-render <https://github.com/ajrcarey/pdfium-render#multi-threading>`_
-offers a ``thread_safe`` compile-time feature (mutex-based locking),
-enabling it would introduce performance overhead in single-threaded
-use, so tablers does not enable it.
+**Thread Safety**: Separate ``Document`` instances may be created and
+used concurrently on different threads. Each document and its pages
+must remain on the thread that created them. Pdfium access is protected
+by pdfium-render's process-wide mutex, so threads are safe but do not
+provide parallel Pdfium execution; use ``multiprocessing`` for that.
 
 **Pickle Support**: All pure-data objects (``Table``, ``TableCell``,
 ``Edge``, ``TfSettings``, ``WordsExtractSettings``, ``Objects``,
@@ -102,10 +95,10 @@ def get_default_pdfium_path() -> Path:
 
 def get_runtime(path: Path | str | None = None) -> PdfiumRuntime:
     """
-    Get a PdfiumRuntime instance, reusing the existing one if already initialized.
+    Create a PdfiumRuntime handle on the current thread.
 
-    If the Pdfium library has already been initialized (either from Python or Rust),
-    the existing instance is reused and the provided path is ignored.
+    Pdfium's native library remains process-global, while each call creates a cheap
+    unsendable PyO3 handle owned by the calling thread.
 
     Parameters
     ----------
@@ -128,9 +121,19 @@ def get_runtime(path: Path | str | None = None) -> PdfiumRuntime:
     return PdfiumRuntime(str(path))
 
 
-# Initialize the global runtime using the default path
-# This will reuse an existing instance if already initialized from Rust
-PDFIUM_RT = get_runtime()
+def _initialize_pdfium() -> None:
+    """Initialize process-global Pdfium without retaining a thread-bound PyO3 handle."""
+    _ = get_runtime()
+
+
+_initialize_pdfium()
+
+
+def __getattr__(name: str) -> PdfiumRuntime:
+    """Resolve the legacy PDFIUM_RT export on the requesting thread."""
+    if name == "PDFIUM_RT":
+        return get_runtime()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def _unwrap_page(page: Page | Pyo3Page | None) -> Pyo3Page | None:
@@ -379,10 +382,9 @@ class Document:
     Either `path` or `bytes` must be provided, but not both.
     Always close the document when done to release resources.
 
-    **Thread Safety**: This class is NOT thread-safe. All
-    operations must be performed on the same thread that
-    imported the ``tablers`` module. Using it from a different
-    thread will raise a ``PanicException``.
+    **Thread Safety**: A document and its pages must remain on the
+    thread that created them. Different threads may safely create
+    and use their own documents concurrently.
     """
 
     _stream: bytes | None  # type hint only; instance value set in __init__
@@ -394,7 +396,7 @@ class Document:
         password: str | None = None,
     ):
         self.doc = Pyo3Doc(
-            PDFIUM_RT,
+            get_runtime(),
             path=str(path) if path is not None else None,
             bytes=bytes,
             password=password,

--- a/tests/python/test_runtime.py
+++ b/tests/python/test_runtime.py
@@ -2,15 +2,49 @@
 Tests for PdfiumRuntime and related functionality.
 """
 
+import os
 import platform
+import subprocess
+import sys
+import textwrap
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 from tablers import (
     Document,
     PdfiumRuntime,
+    find_tables,
     get_default_pdfium_path,
     get_runtime,
 )
+
+
+def _minimal_pdf_bytes() -> bytes:
+    """Build a synthetic one-page PDF without relying on a PDF test dependency."""
+    objects = (
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 300] /Contents 4 0 R >>",
+        b"<< /Length 0 >>\nstream\n\nendstream",
+    )
+    content = bytearray(b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n")
+    offsets = [0]
+    for number, body in enumerate(objects, start=1):
+        offsets.append(len(content))
+        content.extend(f"{number} 0 obj\n".encode())
+        content.extend(body)
+        content.extend(b"\nendobj\n")
+    xref_offset = len(content)
+    content.extend(f"xref\n0 {len(objects) + 1}\n".encode())
+    content.extend(b"0000000000 65535 f \n")
+    for offset in offsets[1:]:
+        content.extend(f"{offset:010d} 00000 n \n".encode())
+    content.extend(
+        f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\n"
+        f"startxref\n{xref_offset}\n%%EOF\n".encode()
+    )
+    return bytes(content)
 
 
 class TestGetDefaultPdfiumPath:
@@ -68,10 +102,9 @@ class TestGetRuntime:
         assert isinstance(runtime, PdfiumRuntime)
 
     def test_multiple_calls_succeed(self) -> None:
-        """Multiple calls to get_runtime should succeed (reusing instance)."""
+        """Multiple calls should create valid handles on the current thread."""
         runtime1 = get_runtime()
         runtime2 = get_runtime()
-        # Both should be valid PdfiumRuntime instances
         assert isinstance(runtime1, PdfiumRuntime)
         assert isinstance(runtime2, PdfiumRuntime)
 
@@ -151,3 +184,101 @@ class TestRuntimeIntegration:
         doc2 = Document(path=edge_test_pdf_path)
         assert doc2.page_count > 0
         doc2.close()
+
+    def test_concurrent_threads_repeatedly_open_synthetic_documents(self, tmp_path: Path) -> None:
+        """Independent thread runtimes should survive sustained Pdfium contention."""
+        pdf_bytes = _minimal_pdf_bytes()
+        pdf_path = tmp_path / "thread-contention.pdf"
+        pdf_path.write_bytes(pdf_bytes)
+        worker_count = 8
+        iterations = 20
+        ready = threading.Barrier(worker_count)
+
+        def hammer_runtime(worker_index: int) -> tuple[int, int]:
+            """Repeatedly open path and byte documents from one synchronized thread."""
+            runtime = get_runtime()
+            assert isinstance(runtime, PdfiumRuntime)
+            ready.wait(timeout=10)
+            completed = 0
+            for iteration in range(iterations):
+                if (worker_index + iteration) % 2 == 0:
+                    document = Document(path=pdf_path)
+                else:
+                    document = Document(bytes=pdf_bytes)
+                with document:
+                    page = document.get_page(0)
+                    assert document.page_count == 1
+                    assert page.width == 200
+                    assert page.height == 300
+                    page.extract_objects()
+                    assert find_tables(page) == []
+                    completed += 1
+            return threading.get_ident(), completed
+
+        with ThreadPoolExecutor(max_workers=worker_count) as executor:
+            results = list(executor.map(hammer_runtime, range(worker_count)))
+
+        assert len({thread_id for thread_id, _ in results}) == worker_count
+        assert all(completed == iterations for _, completed in results)
+
+    def test_replacement_worker_threads_get_fresh_runtime_handles(self, tmp_path: Path) -> None:
+        """Short-lived replacement workers should each create usable documents."""
+        pdf_path = tmp_path / "replacement-workers.pdf"
+        pdf_path.write_bytes(_minimal_pdf_bytes())
+        results: list[tuple[int, int]] = []
+
+        def inspect_document() -> None:
+            """Read the synthetic document entirely inside one short-lived thread."""
+            with Document(path=pdf_path) as document:
+                results.append((threading.get_ident(), document.page_count))
+
+        for _ in range(20):
+            worker = threading.Thread(target=inspect_document)
+            worker.start()
+            worker.join(timeout=10)
+            assert not worker.is_alive()
+
+        assert len(results) == 20
+        assert all(page_count == 1 for _, page_count in results)
+
+    def test_first_import_on_worker_thread_shuts_down_cleanly(self, tmp_path: Path) -> None:
+        """A fresh process should not retain an import-worker runtime until shutdown."""
+        pdf_path = tmp_path / "worker-first-import.pdf"
+        pdf_path.write_bytes(_minimal_pdf_bytes())
+        package_root = Path(sys.modules[Document.__module__].__file__).resolve().parent.parent
+        environment = os.environ.copy()
+        environment["PYTHONPATH"] = os.pathsep.join(
+            filter(None, (str(package_root), environment.get("PYTHONPATH", "")))
+        )
+        script = textwrap.dedent(
+            """
+            import sys
+            import threading
+
+            results = []
+
+            def inspect_document():
+                from tablers import Document
+
+                with Document(path=sys.argv[1]) as document:
+                    results.append(document.page_count)
+
+            worker = threading.Thread(target=inspect_document)
+            worker.start()
+            worker.join(timeout=10)
+            if worker.is_alive() or results != [1]:
+                raise RuntimeError(f"worker result: {results!r}")
+            """
+        )
+
+        completed = subprocess.run(
+            [sys.executable, "-c", script, str(pdf_path)],
+            capture_output=True,
+            check=False,
+            env=environment,
+            text=True,
+            timeout=20,
+        )
+
+        assert completed.returncode == 0, completed.stderr
+        assert "unsendable" not in completed.stderr


### PR DESCRIPTION
## Summary

Allow applications to import Tablers on one thread and later create independent `Document` instances on arbitrary worker threads without triggering PyO3's `PanicException` for an unsendable `PdfiumRuntime`.

## Root cause

Tablers initializes the public `PDFIUM_RT` handle when the Python package is imported. `PdfiumRuntime`, `Pyo3Doc`, and `Pyo3Page` are intentionally declared `unsendable` because their Rust implementations contain thread-affine `Rc`/`RefCell` state. `Document.__init__()` always passed the import-thread `PDFIUM_RT` into `Pyo3Doc`, so creating a brand-new document on any other thread still crossed the PyO3 affinity boundary.

This was stricter than the native dependency requires. Pdfium itself remains process-global and does not promise thread safety, but pdfium-render provides a mutex-backed `thread_safe` feature that serializes all Pdfium calls safely across threads.

## Implementation

- Explicitly enable pdfium-render's `thread_safe` feature instead of relying on its current default-feature set.
- Initialize the process-global native Pdfium instance without retaining its temporary PyO3 handle.
- Create a cheap `PdfiumRuntime` PyO3 handle inside `Document.__init__()` on the calling thread and let that handle release implicitly on the same thread.
- Keep the native Pdfium library initialized once per process through the existing Rust `OnceLock<Pdfium>`.
- Preserve `PDFIUM_RT` for low-level backwards compatibility as a dynamic export that resolves a new handle on the accessing thread.

## Safety and performance contract

- Different threads may create and use separate `Document` instances safely.
- Each `Document` and its `Page` objects must remain on the thread that created the document; the PyO3 classes remain `unsendable`.
- Pure-data outputs such as tables, cells, and edges may still cross thread or process boundaries.
- Threads provide integration safety, not parallel Pdfium execution: pdfium-render's mutex serializes native Pdfium calls.
- Applications requiring actual parallel PDF processing should continue using multiple processes.

## Regression coverage

The tests construct their PDFs synthetically at runtime and do not contain customer or corpus data.

- Eight synchronized worker threads contend for Pdfium while performing 160 total document lifecycles.
- Workers alternate between path-backed and byte-backed documents.
- Every cycle opens the document, reads page metadata, extracts page objects, invokes table detection, and closes the document.
- Workers also exercise direct current-thread runtime-handle creation.
- Twenty additional short-lived replacement threads reproduce worker teardown/recreation patterns such as repeated GUI rescans.
- The package is imported on the test runner's main thread before any worker starts, reproducing the original failure condition.
- A fresh-interpreter subprocess performs its first-ever Tablers import inside a worker thread and then exits cleanly, guarding against wrong-thread handle destruction during interpreter shutdown.

## Validation

- Python suite: 289 passed, 2 skipped.
- Ruff lint: passed.
- Ruff formatting check: passed.
- rumdl documentation lint: passed.
- Git diff whitespace check: passed.
- The new stress tests were also exercised against the existing Windows native extension, whose pinned pdfium-render revision already includes mutex-backed thread safety by default.
- Earlier retained-handle prototypes were rejected because interpreter teardown can release an unsendable PyO3 handle from a different thread; the submitted implementation keeps no cross-thread, module-global, or thread-local handle cache.

Local Rust validation was unavailable because the Windows host has no Cargo toolchain. The repository's Rust build, tests, Clippy, and cross-platform wheel jobs are expected to provide that coverage in CI.
